### PR TITLE
Add CLAUDE.md and agent skills

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: architecture
+description: System architecture reference for StartupTracker. Use when making design decisions or understanding how components connect.
+---
+
+# StartupTracker Architecture
+
+## System Overview
+```
+[News Sources / RSS] --> [Ingestion Pipeline] --> [PostgreSQL]
+                              |                       |
+                         [LLM Extract]           [FastAPI API]
+                         [Normalize]                  |
+                         [Dedup]              [Next.js Frontend]
+```
+
+## Database Schema (5 tables)
+
+### companies
+- id (uuid pk), name, normalized_name (indexed), website, created_at
+
+### funding_rounds
+- id (uuid pk), company_id (fk -> companies, indexed), round_type, amount_usd, valuation_usd, announced_date, source_url, created_at
+
+### investors
+- id (uuid pk), name, normalized_name (indexed)
+
+### round_investors (join table)
+- round_id (fk -> funding_rounds), investor_id (fk -> investors) — composite PK
+
+### raw_sources
+- id (uuid pk), source_url (unique indexed), title, content, processed (bool), created_at
+
+## Backend Services (app/services/)
+- `db.py` - async DB session factory (exists)
+- `crud.py` - CRUD helpers (PR 7)
+- `ingestion.py` - full pipeline orchestrator (PR 17)
+- `llm.py` - LLM extraction with caching (PR 12)
+- `normalization.py` - name/date/currency normalization (PR 13)
+- `fetcher.py` - article/RSS fetching with trafilatura (PR 14)
+- `dedup.py` - company/round/investor dedup with rapidfuzz (PRs 15-16)
+- `batch.py` - batch RSS processing (PR 18)
+
+## API Endpoints (app/routes/)
+- `GET /health` - health check (exists)
+- `GET /companies` - search + paginated list (PR 8)
+- `GET /companies/{id}` - detail with rounds + investors (PR 9)
+- `GET /funding-rounds` - filtered/sorted list (PR 10)
+- `POST /ingest` - single article ingestion (PR 11/17)
+- `POST /ingest/batch` - RSS feed batch ingestion (PR 18)
+
+## Frontend Pages (frontend/)
+- `/` - company search + list (PR 20)
+- `/companies/[id]` - company detail + timeline (PR 21)
+- `/funding-rounds` - filterable table (PR 22)
+
+## Data Flow: Article Ingestion
+1. Fetch article URL or RSS feed
+2. Extract text with trafilatura
+3. Store in raw_sources (idempotent via unique source_url)
+4. Send to LLM for structured extraction (JSON)
+5. Validate + normalize output
+6. Deduplicate company (normalized name + fuzzy match)
+7. Deduplicate round (company + type + date window)
+8. Insert/update structured tables
+9. Mark raw_source as processed
+
+## Dedup Strategy
+- **Companies**: normalized name exact match, then Levenshtein (rapidfuzz) > threshold
+- **Rounds**: same company + same round_type + within 7 days + similar amount
+- **Investors**: normalized name + fuzzy match

--- a/.claude/skills/create-backend-pr/SKILL.md
+++ b/.claude/skills/create-backend-pr/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: create-backend-pr
+description: Steps to create a backend PR that passes CI. Use when implementing any backend feature.
+---
+
+# Create Backend PR
+
+## Before coding
+1. Check out main and pull latest: `git checkout main && git pull`
+2. Create feature branch: `git checkout -b NN-feature-name`
+3. Check the execution plan in `.context/plans/startuptracker-execution-plan.md` for what this PR should contain
+
+## While coding
+- Keep lines under 100 chars
+- Use `from collections.abc import Sequence` not `from typing import Sequence`
+- Use `X | None` not `Optional[X]` or `Union[X, None]`
+- Import order: stdlib -> third-party -> local (ruff I001 enforces this)
+- SQLAlchemy models use `mapped_column()` style, not legacy `Column()` (except for Table associations)
+- Pydantic schemas use `model_config = ConfigDict(from_attributes=True)`
+
+## Before pushing
+```bash
+cd backend
+ruff check .            # lint
+ruff format .           # format
+pytest -v               # test
+```
+All three must pass — CI runs them separately.
+
+## Creating the PR
+1. `git add <specific files>` (never `git add .`)
+2. `git commit -m "Description\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"`
+3. `git push origin NN-feature-name -u`
+4. `gh pr create --base main --title "Short title" --body "## Summary\n- bullets\n\nCloses #N"`
+
+## After PR is created
+- Wait for CI to pass
+- If CI fails, check `gh run view <id> --log-failed | tail -30`
+- Common failures: ruff format (separate from ruff check), line too long in alembic files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# StartupTracker - Claude Agent Context
+
+## Project Overview
+Personal "Crunchbase-like" startup funding tracker. FastAPI backend + Next.js frontend + PostgreSQL (Supabase) + LLM extraction pipeline.
+
+## Repo Structure
+```
+backend/          # FastAPI app
+  app/
+    routes/       # API endpoints
+    services/     # Business logic (ingestion, llm, dedup, db)
+    models/       # SQLAlchemy ORM models
+    schemas/      # Pydantic request/response schemas
+  alembic/        # DB migrations
+  tests/
+frontend/         # Next.js app (App Router, TypeScript, Tailwind)
+docker-compose.yml  # Local Postgres
+```
+
+## CI Pipelines
+
+### Backend CI (`.github/workflows/backend-ci.yml`)
+Triggers on pushes/PRs touching `backend/**`.
+Steps:
+1. `pip install -e ".[dev]"` (Python 3.11)
+2. `ruff check .` - linting (rules: E, F, I, N, W, UP; line-length=100)
+3. `ruff format --check .` - formatting
+4. `pytest -v`
+
+Working directory: `backend/`
+
+### Frontend CI (`.github/workflows/frontend-ci.yml`)
+Triggers on pushes/PRs touching `frontend/**`.
+Steps: ESLint + typecheck + build.
+
+## Pre-PR Checklist (Backend)
+Before pushing a backend branch:
+```bash
+cd backend
+ruff check .          # fix lint errors
+ruff format .         # fix formatting
+pytest -v             # run tests
+```
+Common gotchas:
+- Line length limit is 100 chars (not 88)
+- `ruff format` and `ruff check` are separate CI steps — passing one doesn't mean the other passes
+- Alembic migration files ARE linted — keep them clean
+- `pyproject.toml` has `[tool.setuptools.packages.find] include = ["app*"]` to exclude alembic from setuptools discovery
+
+## Pre-PR Checklist (Frontend)
+```bash
+cd frontend
+npm run lint
+npx tsc --noEmit
+npm run build
+```
+
+## Branch & Merge Conventions
+- PRs are stacked in dependency order (see execution plan in `.context/plans/`)
+- Each PR has a corresponding GitHub issue
+- Merge order matters — downstream PRs rebase onto upstream fixes
+- Branch naming: `NN-feature-name` (e.g., `07-db-crud-service`)
+
+## Key Tech Decisions
+- Alembic for DB migrations (async with asyncpg)
+- rapidfuzz for fuzzy matching/dedup
+- trafilatura for article text extraction
+- LLM is extractor only (no reasoning), cost-optimized prompts
+- Render for backend hosting, Vercel for frontend
+- SQLAlchemy async ORM with mapped_column style
+
+## Database
+- Local dev: `docker-compose up -d` starts Postgres on port 5432
+- 5 tables: companies, funding_rounds, investors, round_investors, raw_sources
+- All PKs are UUID with `gen_random_uuid()`
+- Indexed: normalized_name (companies, investors), company_id (funding_rounds), source_url (raw_sources, unique)


### PR DESCRIPTION
## Summary
- Add `CLAUDE.md` with project context, CI details, pre-PR checklists, and key tech decisions
- Add `.claude/skills/create-backend-pr/SKILL.md` for backend PR workflow
- Add `.claude/skills/architecture/SKILL.md` for system architecture reference

## Test plan
- [ ] Verify files are present and readable
- [ ] CI passes (no backend/frontend code changed)

Generated with [Claude Code](https://claude.com/claude-code)