### PR TITLE
Async CRUD service helpers

### DIFF
--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -1,0 +1,263 @@
+import re
+import uuid
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.company import Company
+from app.models.funding_round import FundingRound
+from app.models.investor import Investor
+from app.models.raw_source import RawSource
+from app.models.round_investor import round_investors
+
+
+def normalize_name(name: str) -> str:
+    """Lowercase, strip common suffixes, collapse whitespace."""
+    n = name.lower().strip()
+    n = re.sub(r"\b(inc|llc|ltd|corp|co|plc)\.?\b", "", n)
+    n = re.sub(r"[^\w\s]", "", n)
+    return re.sub(r"\s+", " ", n).strip()
+
+
+# ---------------------------------------------------------------------------
+# Companies
+# ---------------------------------------------------------------------------
+
+
+async def create_company(
+    session: AsyncSession,
+    name: str,
+    website: str | None = None,
+) -> Company:
+    company = Company(
+        name=name,
+        normalized_name=normalize_name(name),
+        website=website,
+    )
+    session.add(company)
+    await session.flush()
+    return company
+
+
+async def get_company(
+    session: AsyncSession,
+    company_id: uuid.UUID,
+) -> Company | None:
+    stmt = (
+        select(Company)
+        .options(selectinload(Company.funding_rounds).selectinload(FundingRound.investors))
+        .where(Company.id == company_id)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_companies(
+    session: AsyncSession,
+    *,
+    search: str | None = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> tuple[list[Company], int]:
+    base = select(Company)
+    count_base = select(func.count()).select_from(Company)
+
+    if search:
+        pattern = f"%{normalize_name(search)}%"
+        base = base.where(Company.normalized_name.ilike(pattern))
+        count_base = count_base.where(Company.normalized_name.ilike(pattern))
+
+    total = (await session.execute(count_base)).scalar_one()
+
+    stmt = base.order_by(Company.name).offset((page - 1) * page_size).limit(page_size)
+    rows = (await session.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+# ---------------------------------------------------------------------------
+# Funding rounds
+# ---------------------------------------------------------------------------
+
+
+async def create_funding_round(
+    session: AsyncSession,
+    *,
+    company_id: uuid.UUID,
+    round_type: str,
+    amount_usd: float | None = None,
+    valuation_usd: float | None = None,
+    announced_date=None,
+    source_url: str | None = None,
+    investor_ids: list[uuid.UUID] | None = None,
+) -> FundingRound:
+    fr = FundingRound(
+        company_id=company_id,
+        round_type=round_type,
+        amount_usd=amount_usd,
+        valuation_usd=valuation_usd,
+        announced_date=announced_date,
+        source_url=source_url,
+    )
+    session.add(fr)
+    await session.flush()
+
+    if investor_ids:
+        for inv_id in investor_ids:
+            await session.execute(
+                round_investors.insert().values(round_id=fr.id, investor_id=inv_id)
+            )
+        await session.flush()
+
+    return fr
+
+
+async def get_funding_round(
+    session: AsyncSession,
+    round_id: uuid.UUID,
+) -> FundingRound | None:
+    stmt = (
+        select(FundingRound)
+        .options(selectinload(FundingRound.investors))
+        .where(FundingRound.id == round_id)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_funding_rounds(
+    session: AsyncSession,
+    *,
+    company_id: uuid.UUID | None = None,
+    round_type: str | None = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> tuple[list[FundingRound], int]:
+    base = select(FundingRound).options(selectinload(FundingRound.investors))
+    count_base = select(func.count()).select_from(FundingRound)
+
+    if company_id:
+        base = base.where(FundingRound.company_id == company_id)
+        count_base = count_base.where(FundingRound.company_id == company_id)
+    if round_type:
+        base = base.where(FundingRound.round_type == round_type)
+        count_base = count_base.where(FundingRound.round_type == round_type)
+
+    total = (await session.execute(count_base)).scalar_one()
+
+    stmt = (
+        base.order_by(FundingRound.announced_date.desc().nullslast())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    rows = (await session.execute(stmt)).scalars().unique().all()
+    return list(rows), total
+
+
+# ---------------------------------------------------------------------------
+# Investors
+# ---------------------------------------------------------------------------
+
+
+async def create_investor(
+    session: AsyncSession,
+    name: str,
+) -> Investor:
+    investor = Investor(name=name, normalized_name=normalize_name(name))
+    session.add(investor)
+    await session.flush()
+    return investor
+
+
+async def get_investor(
+    session: AsyncSession,
+    investor_id: uuid.UUID,
+) -> Investor | None:
+    stmt = select(Investor).where(Investor.id == investor_id)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_investors(
+    session: AsyncSession,
+    *,
+    search: str | None = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> tuple[list[Investor], int]:
+    base = select(Investor)
+    count_base = select(func.count()).select_from(Investor)
+
+    if search:
+        pattern = f"%{normalize_name(search)}%"
+        base = base.where(Investor.normalized_name.ilike(pattern))
+        count_base = count_base.where(Investor.normalized_name.ilike(pattern))
+
+    total = (await session.execute(count_base)).scalar_one()
+
+    stmt = base.order_by(Investor.name).offset((page - 1) * page_size).limit(page_size)
+    rows = (await session.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def get_investor_by_normalized_name(
+    session: AsyncSession,
+    normalized_name: str,
+) -> Investor | None:
+    stmt = select(Investor).where(Investor.normalized_name == normalized_name)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+# ---------------------------------------------------------------------------
+# Raw sources
+# ---------------------------------------------------------------------------
+
+
+async def create_raw_source(
+    session: AsyncSession,
+    *,
+    source_url: str,
+    title: str | None = None,
+    content: str | None = None,
+) -> RawSource:
+    rs = RawSource(source_url=source_url, title=title, content=content)
+    session.add(rs)
+    await session.flush()
+    return rs
+
+
+async def get_raw_source_by_url(
+    session: AsyncSession,
+    source_url: str,
+) -> RawSource | None:
+    stmt = select(RawSource).where(RawSource.source_url == source_url)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_unprocessed_sources(
+    session: AsyncSession,
+    *,
+    limit: int = 50,
+) -> list[RawSource]:
+    stmt = (
+        select(RawSource)
+        .where(RawSource.processed.is_(False))
+        .order_by(RawSource.created_at)
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).scalars().all()
+    return list(rows)
+
+
+async def mark_source_processed(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> None:
+    stmt = select(RawSource).where(RawSource.id == source_id)
+    result = await session.execute(stmt)
+    rs = result.scalar_one_or_none()
+    if rs:
+        rs.processed = True
+        await session.flush()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.25.0",
+    "aiosqlite>=0.20.0",
     "httpx>=0.28.0",
     "ruff>=0.9.0",
 ]

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,28 @@
+import pytest
+from sqlalchemy import event
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.models.base import Base
+
+
+@pytest.fixture
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+
+    # SQLite doesn't support gen_random_uuid() or now(), provide fallbacks
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_functions(dbapi_conn, _record):
+        import datetime as _dt
+        import uuid as _uuid
+
+        dbapi_conn.create_function("gen_random_uuid", 0, lambda: _uuid.uuid4().hex)
+        dbapi_conn.create_function("now", 0, lambda: _dt.datetime.now(_dt.UTC).isoformat())
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async_sess = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_sess() as s:
+        yield s
+
+    await engine.dispose()

--- a/backend/tests/test_crud.py
+++ b/backend/tests/test_crud.py
@@ -1,0 +1,202 @@
+import pytest
+
+from app.services.crud import (
+    create_company,
+    create_funding_round,
+    create_investor,
+    create_raw_source,
+    get_company,
+    get_investor,
+    get_investor_by_normalized_name,
+    get_raw_source_by_url,
+    list_companies,
+    list_funding_rounds,
+    list_investors,
+    list_unprocessed_sources,
+    mark_source_processed,
+    normalize_name,
+)
+
+# ---------------------------------------------------------------------------
+# normalize_name
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeName:
+    def test_basic(self):
+        assert normalize_name("OpenAI") == "openai"
+
+    def test_strip_suffix(self):
+        assert normalize_name("Acme Inc.") == "acme"
+        assert normalize_name("Widgets LLC") == "widgets"
+
+    def test_collapse_whitespace(self):
+        assert normalize_name("  Some   Company  ") == "some company"
+
+
+# ---------------------------------------------------------------------------
+# Companies
+# ---------------------------------------------------------------------------
+
+
+class TestCompanyCrud:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, session):
+        c = await create_company(session, "Acme Inc.", website="https://acme.com")
+        await session.flush()
+
+        fetched = await get_company(session, c.id)
+        assert fetched is not None
+        assert fetched.name == "Acme Inc."
+        assert fetched.normalized_name == "acme"
+        assert fetched.website == "https://acme.com"
+
+    @pytest.mark.asyncio
+    async def test_list_with_search(self, session):
+        await create_company(session, "Alpha Corp")
+        await create_company(session, "Beta Ltd")
+        await create_company(session, "Alphabetical Inc")
+        await session.commit()
+
+        results, total = await list_companies(session, search="alpha")
+        assert total == 2
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_pagination(self, session):
+        for i in range(5):
+            await create_company(session, f"Company {i}")
+        await session.commit()
+
+        page1, total = await list_companies(session, page=1, page_size=2)
+        assert total == 5
+        assert len(page1) == 2
+
+        page3, _ = await list_companies(session, page=3, page_size=2)
+        assert len(page3) == 1
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent(self, session):
+        import uuid
+
+        result = await get_company(session, uuid.uuid4())
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Funding rounds
+# ---------------------------------------------------------------------------
+
+
+class TestFundingRoundCrud:
+    @pytest.mark.asyncio
+    async def test_create_with_investors(self, session):
+        c = await create_company(session, "TestCo")
+        inv = await create_investor(session, "Sequoia Capital")
+        await session.commit()
+
+        fr = await create_funding_round(
+            session,
+            company_id=c.id,
+            round_type="Series A",
+            amount_usd=10_000_000,
+            investor_ids=[inv.id],
+        )
+        await session.commit()
+
+        assert fr.round_type == "Series A"
+        assert fr.company_id == c.id
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_company(self, session):
+        c1 = await create_company(session, "Co1")
+        c2 = await create_company(session, "Co2")
+        await create_funding_round(session, company_id=c1.id, round_type="Seed")
+        await create_funding_round(session, company_id=c2.id, round_type="Series A")
+        await session.commit()
+
+        results, total = await list_funding_rounds(session, company_id=c1.id)
+        assert total == 1
+        assert results[0].round_type == "Seed"
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_type(self, session):
+        c = await create_company(session, "Co")
+        await create_funding_round(session, company_id=c.id, round_type="Seed")
+        await create_funding_round(session, company_id=c.id, round_type="Series A")
+        await session.commit()
+
+        results, total = await list_funding_rounds(session, round_type="Seed")
+        assert total == 1
+
+
+# ---------------------------------------------------------------------------
+# Investors
+# ---------------------------------------------------------------------------
+
+
+class TestInvestorCrud:
+    @pytest.mark.asyncio
+    async def test_create_and_search(self, session):
+        await create_investor(session, "Andreessen Horowitz")
+        await create_investor(session, "Sequoia Capital")
+        await session.commit()
+
+        results, total = await list_investors(session, search="sequoia")
+        assert total == 1
+        assert results[0].name == "Sequoia Capital"
+
+    @pytest.mark.asyncio
+    async def test_get_by_normalized_name(self, session):
+        await create_investor(session, "Y Combinator")
+        await session.commit()
+
+        inv = await get_investor_by_normalized_name(session, "y combinator")
+        assert inv is not None
+        assert inv.name == "Y Combinator"
+
+    @pytest.mark.asyncio
+    async def test_get_investor(self, session):
+        created = await create_investor(session, "Tiger Global")
+        await session.flush()
+
+        fetched = await get_investor(session, created.id)
+        assert fetched is not None
+        assert fetched.name == "Tiger Global"
+
+
+# ---------------------------------------------------------------------------
+# Raw sources
+# ---------------------------------------------------------------------------
+
+
+class TestRawSourceCrud:
+    @pytest.mark.asyncio
+    async def test_create_and_find_by_url(self, session):
+        rs = await create_raw_source(
+            session,
+            source_url="https://example.com/article1",
+            title="Test Article",
+        )
+        await session.commit()
+
+        found = await get_raw_source_by_url(session, "https://example.com/article1")
+        assert found is not None
+        assert found.id == rs.id
+
+    @pytest.mark.asyncio
+    async def test_unprocessed_list_and_mark(self, session):
+        rs = await create_raw_source(
+            session,
+            source_url="https://example.com/a",
+        )
+        await session.flush()
+
+        unprocessed = await list_unprocessed_sources(session)
+        assert len(unprocessed) == 1
+
+        await mark_source_processed(session, rs.id)
+        await session.flush()
+
+        unprocessed = await list_unprocessed_sources(session)
+        assert len(unprocessed) == 0


### PR DESCRIPTION
Adds async CRUD helpers for companies, funding rounds, investors, and raw sources with pagination, search, and name normalization. Includes 16 unit tests using SQLite. Closes #16