### PR TITLE
Backend API extensions: investors, stats, company names

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -7,6 +7,8 @@ from app.routes.companies import router as companies_router
 from app.routes.funding_rounds import router as funding_rounds_router
 from app.routes.health import router as health_router
 from app.routes.ingest import router as ingest_router
+from app.routes.investors import router as investors_router
+from app.routes.stats import router as stats_router
 
 app = FastAPI(title="StartupTracker API", version="0.1.0")
 
@@ -22,3 +24,5 @@ app.include_router(health_router)
 app.include_router(companies_router)
 app.include_router(funding_rounds_router)
 app.include_router(ingest_router)
+app.include_router(investors_router)
+app.include_router(stats_router)

--- a/backend/app/models/funding_round.py
+++ b/backend/app/models/funding_round.py
@@ -4,6 +4,7 @@ from decimal import Decimal
 
 from sqlalchemy import Date, ForeignKey, Numeric, Text
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base, TimestampMixin, pk_uuid
@@ -27,3 +28,7 @@ class FundingRound(Base, TimestampMixin):
 
     company = relationship("Company", back_populates="funding_rounds")
     investors = relationship("Investor", secondary="round_investors", lazy="selectin")
+
+    @hybrid_property
+    def company_name(self) -> str | None:
+        return self.company.name if self.company else None

--- a/backend/app/routes/investors.py
+++ b/backend/app/routes/investors.py
@@ -1,0 +1,38 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.common import PaginatedResponse
+from app.schemas.investor import InvestorResponse
+from app.services.crud import get_investor, list_investors
+from app.services.db import get_session
+
+router = APIRouter(prefix="/investors", tags=["investors"])
+
+
+@router.get("", response_model=PaginatedResponse)
+async def list_investors_endpoint(
+    search: str | None = Query(None, description="Search by investor name"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+):
+    investors, total = await list_investors(session, search=search, page=page, page_size=page_size)
+    return PaginatedResponse(
+        items=[InvestorResponse.model_validate(i) for i in investors],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/{investor_id}", response_model=InvestorResponse)
+async def get_investor_endpoint(
+    investor_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+):
+    investor = await get_investor(session, investor_id)
+    if not investor:
+        raise HTTPException(status_code=404, detail="Investor not found")
+    return InvestorResponse.model_validate(investor)

--- a/backend/app/routes/stats.py
+++ b/backend/app/routes/stats.py
@@ -1,0 +1,23 @@
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.crud import get_stats
+from app.services.db import get_session
+
+
+class StatsResponse(BaseModel):
+    total_companies: int
+    total_rounds: int
+    total_investors: int
+    total_funding_usd: float
+
+
+router = APIRouter(prefix="/stats", tags=["stats"])
+
+
+@router.get("", response_model=StatsResponse)
+async def get_stats_endpoint(
+    session: AsyncSession = Depends(get_session),
+):
+    return await get_stats(session)

--- a/backend/app/schemas/funding_round.py
+++ b/backend/app/schemas/funding_round.py
@@ -22,6 +22,7 @@ class FundingRoundCreate(FundingRoundBase):
 class FundingRoundResponse(FundingRoundBase):
     id: uuid.UUID
     company_id: uuid.UUID
+    company_name: str | None = None
     created_at: datetime
     investors: list[InvestorResponse] = []
 

--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -133,7 +133,10 @@ async def list_funding_rounds(
     page: int = 1,
     page_size: int = 20,
 ) -> tuple[list[FundingRound], int]:
-    base = select(FundingRound).options(selectinload(FundingRound.investors))
+    base = select(FundingRound).options(
+        selectinload(FundingRound.investors),
+        selectinload(FundingRound.company),
+    )
     count_base = select(func.count()).select_from(FundingRound)
 
     if company_id:
@@ -261,3 +264,29 @@ async def mark_source_processed(
     if rs:
         rs.processed = True
         await session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+
+async def get_stats(session: AsyncSession) -> dict:
+    total_companies = (
+        await session.execute(select(func.count()).select_from(Company))
+    ).scalar_one()
+    total_rounds = (
+        await session.execute(select(func.count()).select_from(FundingRound))
+    ).scalar_one()
+    total_investors = (
+        await session.execute(select(func.count()).select_from(Investor))
+    ).scalar_one()
+    total_funding = (
+        await session.execute(select(func.coalesce(func.sum(FundingRound.amount_usd), 0)))
+    ).scalar_one()
+    return {
+        "total_companies": total_companies,
+        "total_rounds": total_rounds,
+        "total_investors": total_investors,
+        "total_funding_usd": float(total_funding),
+    }

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -155,3 +155,89 @@ class TestIngestAPI:
         resp2 = await client.post("/ingest", json=payload)
         assert resp2.status_code == 200
         assert resp2.json()["id"] == resp1.json()["id"]
+
+
+class TestInvestorsAPI:
+    @pytest.mark.asyncio
+    async def test_list_empty(self, client):
+        resp = await client.get("/investors")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_with_data(self, client, session):
+        await create_investor(session, "Sequoia Capital")
+        await create_investor(session, "Andreessen Horowitz")
+        await session.flush()
+
+        resp = await client.get("/investors")
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 2
+
+    @pytest.mark.asyncio
+    async def test_search(self, client, session):
+        await create_investor(session, "Sequoia Capital")
+        await create_investor(session, "Andreessen Horowitz")
+        await session.flush()
+
+        resp = await client.get("/investors", params={"search": "sequoia"})
+        assert resp.status_code == 200
+        assert resp.json()["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_by_id(self, client, session):
+        inv = await create_investor(session, "Sequoia Capital")
+        await session.flush()
+
+        resp = await client.get(f"/investors/{inv.id}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Sequoia Capital"
+
+    @pytest.mark.asyncio
+    async def test_get_404(self, client):
+        resp = await client.get("/investors/00000000-0000-0000-0000-000000000000")
+        assert resp.status_code == 404
+
+
+class TestStatsAPI:
+    @pytest.mark.asyncio
+    async def test_empty_stats(self, client):
+        resp = await client.get("/stats")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total_companies"] == 0
+        assert data["total_rounds"] == 0
+        assert data["total_investors"] == 0
+        assert data["total_funding_usd"] == 0
+
+    @pytest.mark.asyncio
+    async def test_stats_with_data(self, client, session):
+        c = await create_company(session, "Acme Corp")
+        inv = await create_investor(session, "VC Fund")
+        await create_funding_round(
+            session,
+            company_id=c.id,
+            round_type="Seed",
+            amount_usd=1_000_000,
+            investor_ids=[inv.id],
+        )
+        await session.flush()
+
+        resp = await client.get("/stats")
+        data = resp.json()
+        assert data["total_companies"] == 1
+        assert data["total_rounds"] == 1
+        assert data["total_investors"] == 1
+        assert data["total_funding_usd"] == 1_000_000
+
+
+class TestFundingRoundCompanyName:
+    @pytest.mark.asyncio
+    async def test_company_name_in_list(self, client, session):
+        c = await create_company(session, "Acme Corp")
+        await create_funding_round(session, company_id=c.id, round_type="Seed", amount_usd=500_000)
+        await session.flush()
+
+        resp = await client.get("/funding-rounds")
+        data = resp.json()
+        assert data["items"][0]["company_name"] == "Acme Corp"


### PR DESCRIPTION
Phase 11: /investors endpoint, /stats dashboard endpoint, company_name in funding round responses. 78 tests passing. Closes #48 #50 #51