### PR TITLE
CI improvements: coverage enforcement and frontend tests

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -31,5 +31,5 @@ jobs:
       - name: Format check with ruff
         run: ruff format --check .
 
-      - name: Run tests
-        run: pytest -v
+      - name: Run tests with coverage
+        run: pytest -v --cov=app --cov-report=term-missing --cov-fail-under=85

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Type check
         run: npx tsc --noEmit
 
+      - name: Run tests
+        run: npm test
+
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary
- Backend CI: add pytest-cov with 85% minimum coverage enforcement
- Frontend CI: add Vitest test step before build

Closes #61

## Test plan
- [x] Backend CI should run tests with coverage reporting
- [x] Frontend CI should run Vitest tests before build
- [ ] Verify both pipelines pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)