### PR TITLE
Add sector taxonomy to companies

### DIFF
--- a/backend/alembic/versions/002_add_sector.py
+++ b/backend/alembic/versions/002_add_sector.py
@@ -1,0 +1,27 @@
+"""Add sector column to companies table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-03-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "002"
+down_revision: str = "001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column("companies", sa.Column("sector", sa.Text(), nullable=True))
+    op.create_index("ix_companies_sector", "companies", ["sector"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_companies_sector", table_name="companies")
+    op.drop_column("companies", "sector")

--- a/backend/app/models/company.py
+++ b/backend/app/models/company.py
@@ -13,5 +13,6 @@ class Company(Base, TimestampMixin):
     name: Mapped[str] = mapped_column(Text, nullable=False)
     normalized_name: Mapped[str] = mapped_column(Text, nullable=False, index=True)
     website: Mapped[str | None] = mapped_column(Text, nullable=True)
+    sector: Mapped[str | None] = mapped_column(Text, nullable=True, index=True)
 
     funding_rounds = relationship("FundingRound", back_populates="company", lazy="selectin")

--- a/backend/app/routes/companies.py
+++ b/backend/app/routes/companies.py
@@ -14,11 +14,14 @@ router = APIRouter(prefix="/companies", tags=["companies"])
 @router.get("", response_model=PaginatedResponse)
 async def list_companies_endpoint(
     search: str | None = Query(None, description="Search by company name"),
+    sector: str | None = Query(None, description="Filter by sector"),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
     session: AsyncSession = Depends(get_session),
 ):
-    companies, total = await list_companies(session, search=search, page=page, page_size=page_size)
+    companies, total = await list_companies(
+        session, search=search, sector=sector, page=page, page_size=page_size
+    )
     return PaginatedResponse(
         items=[CompanyResponse.model_validate(c) for c in companies],
         total=total,

--- a/backend/app/schemas/company.py
+++ b/backend/app/schemas/company.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 class CompanyBase(BaseModel):
     name: str
     website: str | None = None
+    sector: str | None = None
 
 
 class CompanyCreate(CompanyBase):

--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -29,11 +29,13 @@ async def create_company(
     session: AsyncSession,
     name: str,
     website: str | None = None,
+    sector: str | None = None,
 ) -> Company:
     company = Company(
         name=name,
         normalized_name=normalize_name(name),
         website=website,
+        sector=sector,
     )
     session.add(company)
     await session.flush()
@@ -57,6 +59,7 @@ async def list_companies(
     session: AsyncSession,
     *,
     search: str | None = None,
+    sector: str | None = None,
     page: int = 1,
     page_size: int = 20,
 ) -> tuple[list[Company], int]:
@@ -67,6 +70,10 @@ async def list_companies(
         pattern = f"%{normalize_name(search)}%"
         base = base.where(Company.normalized_name.ilike(pattern))
         count_base = count_base.where(Company.normalized_name.ilike(pattern))
+
+    if sector:
+        base = base.where(Company.sector == sector)
+        count_base = count_base.where(Company.sector == sector)
 
     total = (await session.execute(count_base)).scalar_one()
 

--- a/backend/app/services/sectors.py
+++ b/backend/app/services/sectors.py
@@ -1,0 +1,30 @@
+"""Sector taxonomy for company classification."""
+
+SECTORS: set[str] = {
+    "AI/ML",
+    "Fintech",
+    "Healthcare/Biotech",
+    "SaaS/Enterprise",
+    "E-Commerce/Retail",
+    "Climate/Energy",
+    "Cybersecurity",
+    "EdTech",
+    "Real Estate/PropTech",
+    "Transportation/Logistics",
+    "Media/Entertainment",
+    "Food/Agriculture",
+    "Hardware/Robotics",
+    "Crypto/Web3",
+    "Other",
+}
+
+SECTORS_LIST: list[str] = sorted(SECTORS)
+
+
+def validate_sector(value: str | None) -> str | None:
+    """Validate a sector value. Returns None for invalid/empty values."""
+    if not value:
+        return None
+    # Case-insensitive match
+    lookup = {s.lower(): s for s in SECTORS}
+    return lookup.get(value.lower())

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -76,6 +76,28 @@ class TestCompaniesAPI:
         assert "funding_rounds" in data
 
     @pytest.mark.asyncio
+    async def test_list_filter_by_sector(self, client, session):
+        await create_company(session, "AI Co", sector="AI/ML")
+        await create_company(session, "Fin Co", sector="Fintech")
+        await session.flush()
+
+        resp = await client.get("/companies", params={"sector": "AI/ML"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["name"] == "AI Co"
+        assert data["items"][0]["sector"] == "AI/ML"
+
+    @pytest.mark.asyncio
+    async def test_detail_includes_sector(self, client, session):
+        c = await create_company(session, "AI Co", sector="AI/ML")
+        await session.flush()
+
+        resp = await client.get(f"/companies/{c.id}")
+        assert resp.status_code == 200
+        assert resp.json()["sector"] == "AI/ML"
+
+    @pytest.mark.asyncio
     async def test_get_404(self, client):
         resp = await client.get("/companies/00000000-0000-0000-0000-000000000000")
         assert resp.status_code == 404

--- a/backend/tests/test_crud.py
+++ b/backend/tests/test_crud.py
@@ -76,6 +76,37 @@ class TestCompanyCrud:
         assert len(page3) == 1
 
     @pytest.mark.asyncio
+    async def test_create_with_sector(self, session):
+        c = await create_company(session, "AI Startup", sector="AI/ML")
+        await session.flush()
+
+        fetched = await get_company(session, c.id)
+        assert fetched is not None
+        assert fetched.sector == "AI/ML"
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_sector(self, session):
+        await create_company(session, "AI Co", sector="AI/ML")
+        await create_company(session, "Fin Co", sector="Fintech")
+        await create_company(session, "AI Co 2", sector="AI/ML")
+        await session.commit()
+
+        results, total = await list_companies(session, sector="AI/ML")
+        assert total == 2
+        assert all(c.sector == "AI/ML" for c in results)
+
+    @pytest.mark.asyncio
+    async def test_list_sector_with_search(self, session):
+        await create_company(session, "Alpha AI", sector="AI/ML")
+        await create_company(session, "Alpha Fin", sector="Fintech")
+        await create_company(session, "Beta AI", sector="AI/ML")
+        await session.commit()
+
+        results, total = await list_companies(session, search="alpha", sector="AI/ML")
+        assert total == 1
+        assert results[0].name == "Alpha AI"
+
+    @pytest.mark.asyncio
     async def test_get_nonexistent(self, session):
         import uuid
 

--- a/backend/tests/test_sectors.py
+++ b/backend/tests/test_sectors.py
@@ -1,0 +1,44 @@
+from app.services.sectors import SECTORS, SECTORS_LIST, validate_sector
+
+
+class TestSectors:
+    def test_sectors_count(self):
+        assert len(SECTORS) == 15
+
+    def test_sectors_list_sorted(self):
+        assert SECTORS_LIST == sorted(SECTORS_LIST)
+
+    def test_validate_valid(self):
+        assert validate_sector("AI/ML") == "AI/ML"
+        assert validate_sector("Fintech") == "Fintech"
+        assert validate_sector("Other") == "Other"
+
+    def test_validate_case_insensitive(self):
+        assert validate_sector("ai/ml") == "AI/ML"
+        assert validate_sector("FINTECH") == "Fintech"
+        assert validate_sector("cybersecurity") == "Cybersecurity"
+
+    def test_validate_invalid(self):
+        assert validate_sector("NotASector") is None
+        assert validate_sector("") is None
+        assert validate_sector(None) is None
+
+    def test_known_sectors(self):
+        expected = {
+            "AI/ML",
+            "Fintech",
+            "Healthcare/Biotech",
+            "SaaS/Enterprise",
+            "E-Commerce/Retail",
+            "Climate/Energy",
+            "Cybersecurity",
+            "EdTech",
+            "Real Estate/PropTech",
+            "Transportation/Logistics",
+            "Media/Entertainment",
+            "Food/Agriculture",
+            "Hardware/Robotics",
+            "Crypto/Web3",
+            "Other",
+        }
+        assert SECTORS == expected


### PR DESCRIPTION
## Summary
- Adds `sector` (Text, nullable, indexed) column to `companies` table via Alembic migration
- Defines 15-category taxonomy in `sectors.py`: AI/ML, Fintech, Healthcare/Biotech, SaaS/Enterprise, E-Commerce/Retail, Climate/Energy, Cybersecurity, EdTech, Real Estate/PropTech, Transportation/Logistics, Media/Entertainment, Food/Agriculture, Hardware/Robotics, Crypto/Web3, Other
- `GET /companies?sector=AI/ML` filtering support
- Case-insensitive `validate_sector()` helper for LLM integration

## Test plan
- [x] 6 new sector-specific tests (validate valid/invalid/case-insensitive, count, known set)
- [x] 3 new CRUD tests (create with sector, filter by sector, combined sector+search)
- [x] 2 new API tests (filter by sector, detail includes sector)
- [x] All 168 existing tests pass

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)