### PR TITLE
Add acquisitions table and API endpoints

### DIFF
--- a/backend/alembic/versions/003_add_acquisitions.py
+++ b/backend/alembic/versions/003_add_acquisitions.py
@@ -1,0 +1,61 @@
+"""Add acquisitions table
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-03-26
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+from alembic import op
+
+revision: str = "003"
+down_revision: str = "002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_uuid_pk = dict(
+    type_=UUID(as_uuid=True),
+    primary_key=True,
+    server_default=sa.text("gen_random_uuid()"),
+)
+_created_at = dict(
+    type_=sa.DateTime(timezone=True),
+    server_default=sa.text("now()"),
+    nullable=False,
+)
+
+
+def upgrade() -> None:
+    op.create_table(
+        "acquisitions",
+        sa.Column("id", **_uuid_pk),
+        sa.Column(
+            "acquirer_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("companies.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "target_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("companies.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("amount_usd", sa.Numeric(), nullable=True),
+        sa.Column("announced_date", sa.Date(), nullable=True),
+        sa.Column("source_url", sa.Text(), nullable=True),
+        sa.Column("confidence_score", sa.Float(), nullable=True),
+        sa.Column("created_at", **_created_at),
+    )
+    op.create_index("ix_acquisitions_acquirer_id", "acquisitions", ["acquirer_id"])
+    op.create_index("ix_acquisitions_target_id", "acquisitions", ["target_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_acquisitions_target_id", table_name="acquisitions")
+    op.drop_index("ix_acquisitions_acquirer_id", table_name="acquisitions")
+    op.drop_table("acquisitions")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ import os
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.routes.acquisitions import router as acquisitions_router
 from app.routes.companies import router as companies_router
 from app.routes.funding_rounds import router as funding_rounds_router
 from app.routes.health import router as health_router
@@ -21,6 +22,7 @@ app.add_middleware(
 )
 
 app.include_router(health_router)
+app.include_router(acquisitions_router)
 app.include_router(companies_router)
 app.include_router(funding_rounds_router)
 app.include_router(ingest_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,3 +1,4 @@
+from app.models.acquisition import Acquisition
 from app.models.base import Base
 from app.models.company import Company
 from app.models.funding_round import FundingRound
@@ -5,4 +6,12 @@ from app.models.investor import Investor
 from app.models.raw_source import RawSource
 from app.models.round_investor import round_investors
 
-__all__ = ["Base", "Company", "FundingRound", "Investor", "RawSource", "round_investors"]
+__all__ = [
+    "Acquisition",
+    "Base",
+    "Company",
+    "FundingRound",
+    "Investor",
+    "RawSource",
+    "round_investors",
+]

--- a/backend/app/models/acquisition.py
+++ b/backend/app/models/acquisition.py
@@ -1,0 +1,33 @@
+import uuid
+from datetime import date
+
+from sqlalchemy import Date, Float, ForeignKey, Numeric, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, pk_uuid
+
+
+class Acquisition(Base, TimestampMixin):
+    __tablename__ = "acquisitions"
+
+    id: Mapped[uuid.UUID] = pk_uuid()
+    acquirer_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("companies.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    target_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("companies.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    amount_usd: Mapped[float | None] = mapped_column(Numeric, nullable=True)
+    announced_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+    confidence_score: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    acquirer = relationship("Company", foreign_keys=[acquirer_id], lazy="selectin")
+    target = relationship("Company", foreign_keys=[target_id], lazy="selectin")

--- a/backend/app/routes/acquisitions.py
+++ b/backend/app/routes/acquisitions.py
@@ -1,0 +1,61 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.acquisition import AcquisitionResponse
+from app.schemas.common import PaginatedResponse
+from app.services.crud import get_acquisition, list_acquisitions
+from app.services.db import get_session
+
+router = APIRouter(prefix="/acquisitions", tags=["acquisitions"])
+
+
+def _to_response(acq) -> dict:
+    """Convert Acquisition ORM to response dict with computed names."""
+    return {
+        "id": acq.id,
+        "acquirer_id": acq.acquirer_id,
+        "acquirer_name": acq.acquirer.name if acq.acquirer else None,
+        "target_id": acq.target_id,
+        "target_name": acq.target.name if acq.target else None,
+        "amount_usd": acq.amount_usd,
+        "announced_date": acq.announced_date,
+        "source_url": acq.source_url,
+        "confidence_score": acq.confidence_score,
+        "created_at": acq.created_at,
+    }
+
+
+@router.get("", response_model=PaginatedResponse)
+async def list_acquisitions_endpoint(
+    acquirer_id: uuid.UUID | None = Query(None),
+    target_id: uuid.UUID | None = Query(None),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+):
+    acquisitions, total = await list_acquisitions(
+        session,
+        acquirer_id=acquirer_id,
+        target_id=target_id,
+        page=page,
+        page_size=page_size,
+    )
+    return PaginatedResponse(
+        items=[AcquisitionResponse.model_validate(_to_response(a)) for a in acquisitions],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/{acquisition_id}", response_model=AcquisitionResponse)
+async def get_acquisition_endpoint(
+    acquisition_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+):
+    acq = await get_acquisition(session, acquisition_id)
+    if not acq:
+        raise HTTPException(status_code=404, detail="Acquisition not found")
+    return AcquisitionResponse.model_validate(_to_response(acq))

--- a/backend/app/schemas/acquisition.py
+++ b/backend/app/schemas/acquisition.py
@@ -1,0 +1,29 @@
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+
+from pydantic import BaseModel
+
+
+class AcquisitionCreate(BaseModel):
+    acquirer_id: uuid.UUID
+    target_id: uuid.UUID
+    amount_usd: Decimal | None = None
+    announced_date: date | None = None
+    source_url: str | None = None
+    confidence_score: float | None = None
+
+
+class AcquisitionResponse(BaseModel):
+    id: uuid.UUID
+    acquirer_id: uuid.UUID
+    acquirer_name: str | None = None
+    target_id: uuid.UUID
+    target_name: str | None = None
+    amount_usd: Decimal | None = None
+    announced_date: date | None = None
+    source_url: str | None = None
+    confidence_score: float | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -5,6 +5,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.models.acquisition import Acquisition
 from app.models.company import Company
 from app.models.funding_round import FundingRound
 from app.models.investor import Investor
@@ -264,6 +265,82 @@ async def mark_source_processed(
     if rs:
         rs.processed = True
         await session.flush()
+
+
+# ---------------------------------------------------------------------------
+# Acquisitions
+# ---------------------------------------------------------------------------
+
+
+async def create_acquisition(
+    session: AsyncSession,
+    *,
+    acquirer_id: uuid.UUID,
+    target_id: uuid.UUID,
+    amount_usd: float | None = None,
+    announced_date=None,
+    source_url: str | None = None,
+    confidence_score: float | None = None,
+) -> Acquisition:
+    acq = Acquisition(
+        acquirer_id=acquirer_id,
+        target_id=target_id,
+        amount_usd=amount_usd,
+        announced_date=announced_date,
+        source_url=source_url,
+        confidence_score=confidence_score,
+    )
+    session.add(acq)
+    await session.flush()
+    return acq
+
+
+async def get_acquisition(
+    session: AsyncSession,
+    acquisition_id: uuid.UUID,
+) -> Acquisition | None:
+    stmt = (
+        select(Acquisition)
+        .options(
+            selectinload(Acquisition.acquirer),
+            selectinload(Acquisition.target),
+        )
+        .where(Acquisition.id == acquisition_id)
+    )
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_acquisitions(
+    session: AsyncSession,
+    *,
+    acquirer_id: uuid.UUID | None = None,
+    target_id: uuid.UUID | None = None,
+    page: int = 1,
+    page_size: int = 20,
+) -> tuple[list[Acquisition], int]:
+    base = select(Acquisition).options(
+        selectinload(Acquisition.acquirer),
+        selectinload(Acquisition.target),
+    )
+    count_base = select(func.count()).select_from(Acquisition)
+
+    if acquirer_id:
+        base = base.where(Acquisition.acquirer_id == acquirer_id)
+        count_base = count_base.where(Acquisition.acquirer_id == acquirer_id)
+    if target_id:
+        base = base.where(Acquisition.target_id == target_id)
+        count_base = count_base.where(Acquisition.target_id == target_id)
+
+    total = (await session.execute(count_base)).scalar_one()
+
+    stmt = (
+        base.order_by(Acquisition.announced_date.desc().nullslast())
+        .offset((page - 1) * page_size)
+        .limit(page_size)
+    )
+    rows = (await session.execute(stmt)).scalars().unique().all()
+    return list(rows), total
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_acquisitions.py
+++ b/backend/tests/test_acquisitions.py
@@ -1,0 +1,181 @@
+import uuid
+from datetime import date
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.main import app
+from app.services.crud import (
+    create_acquisition,
+    create_company,
+    get_acquisition,
+    list_acquisitions,
+)
+from app.services.db import get_session
+
+# ---------------------------------------------------------------------------
+# CRUD tests
+# ---------------------------------------------------------------------------
+
+
+class TestAcquisitionCrud:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, session):
+        acquirer = await create_company(session, "BigCorp")
+        target = await create_company(session, "SmallStartup")
+        await session.flush()
+
+        acq = await create_acquisition(
+            session,
+            acquirer_id=acquirer.id,
+            target_id=target.id,
+            amount_usd=50_000_000,
+            announced_date=date(2026, 1, 15),
+            source_url="https://example.com/acq",
+            confidence_score=0.92,
+        )
+        await session.flush()
+
+        fetched = await get_acquisition(session, acq.id)
+        assert fetched is not None
+        assert fetched.acquirer_id == acquirer.id
+        assert fetched.target_id == target.id
+        assert float(fetched.amount_usd) == 50_000_000
+        assert fetched.confidence_score == 0.92
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent(self, session):
+        result = await get_acquisition(session, uuid.uuid4())
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_list_all(self, session):
+        c1 = await create_company(session, "Acquirer1")
+        c2 = await create_company(session, "Target1")
+        c3 = await create_company(session, "Target2")
+        await create_acquisition(session, acquirer_id=c1.id, target_id=c2.id)
+        await create_acquisition(session, acquirer_id=c1.id, target_id=c3.id)
+        await session.flush()
+
+        results, total = await list_acquisitions(session)
+        assert total == 2
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_acquirer(self, session):
+        c1 = await create_company(session, "Acquirer1")
+        c2 = await create_company(session, "Acquirer2")
+        c3 = await create_company(session, "Target1")
+        await create_acquisition(session, acquirer_id=c1.id, target_id=c3.id)
+        await create_acquisition(session, acquirer_id=c2.id, target_id=c3.id)
+        await session.flush()
+
+        results, total = await list_acquisitions(session, acquirer_id=c1.id)
+        assert total == 1
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_target(self, session):
+        c1 = await create_company(session, "Acquirer")
+        c2 = await create_company(session, "Target1")
+        c3 = await create_company(session, "Target2")
+        await create_acquisition(session, acquirer_id=c1.id, target_id=c2.id)
+        await create_acquisition(session, acquirer_id=c1.id, target_id=c3.id)
+        await session.flush()
+
+        results, total = await list_acquisitions(session, target_id=c2.id)
+        assert total == 1
+
+    @pytest.mark.asyncio
+    async def test_create_minimal(self, session):
+        c1 = await create_company(session, "A")
+        c2 = await create_company(session, "B")
+        acq = await create_acquisition(session, acquirer_id=c1.id, target_id=c2.id)
+        await session.flush()
+
+        assert acq.amount_usd is None
+        assert acq.announced_date is None
+        assert acq.confidence_score is None
+
+
+# ---------------------------------------------------------------------------
+# API tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def client(session: AsyncSession):
+    async def _override():
+        yield session
+
+    app.dependency_overrides[get_session] = _override
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+    app.dependency_overrides.clear()
+
+
+class TestAcquisitionsAPI:
+    @pytest.mark.asyncio
+    async def test_list_empty(self, client):
+        resp = await client.get("/acquisitions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["items"] == []
+        assert data["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_list_with_data(self, client, session):
+        c1 = await create_company(session, "BigCo")
+        c2 = await create_company(session, "SmallCo")
+        await create_acquisition(
+            session,
+            acquirer_id=c1.id,
+            target_id=c2.id,
+            amount_usd=10_000_000,
+        )
+        await session.flush()
+
+        resp = await client.get("/acquisitions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        item = data["items"][0]
+        assert item["acquirer_name"] == "BigCo"
+        assert item["target_name"] == "SmallCo"
+
+    @pytest.mark.asyncio
+    async def test_get_detail(self, client, session):
+        c1 = await create_company(session, "Buyer")
+        c2 = await create_company(session, "Seller")
+        acq = await create_acquisition(
+            session,
+            acquirer_id=c1.id,
+            target_id=c2.id,
+            amount_usd=5_000_000,
+            confidence_score=0.85,
+        )
+        await session.flush()
+
+        resp = await client.get(f"/acquisitions/{acq.id}")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["acquirer_name"] == "Buyer"
+        assert data["target_name"] == "Seller"
+        assert data["confidence_score"] == 0.85
+
+    @pytest.mark.asyncio
+    async def test_get_404(self, client):
+        resp = await client.get("/acquisitions/00000000-0000-0000-0000-000000000000")
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_filter_by_acquirer(self, client, session):
+        c1 = await create_company(session, "Buyer1")
+        c2 = await create_company(session, "Buyer2")
+        c3 = await create_company(session, "Target")
+        await create_acquisition(session, acquirer_id=c1.id, target_id=c3.id)
+        await create_acquisition(session, acquirer_id=c2.id, target_id=c3.id)
+        await session.flush()
+
+        resp = await client.get("/acquisitions", params={"acquirer_id": str(c1.id)})
+        assert resp.json()["total"] == 1


### PR DESCRIPTION
## Summary
- New `acquisitions` table with Alembic migration (acquirer_id, target_id FK→companies, amount_usd, announced_date, source_url, confidence_score)
- SQLAlchemy model with eager-loaded acquirer/target relationships
- CRUD: `create_acquisition()`, `get_acquisition()`, `list_acquisitions()` with acquirer/target filtering
- API: `GET /acquisitions` (paginated, filterable) and `GET /acquisitions/{id}` with computed acquirer_name/target_name
- Pydantic schemas with `from_attributes` support

## Test plan
- [x] 6 CRUD tests (create, get, list, filter by acquirer/target, minimal create, nonexistent)
- [x] 5 API tests (list empty, list with data, get detail, 404, filter by acquirer)
- [x] All 168 tests pass

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)