### PR TITLE
Add monitored sources DB table and API

### DIFF
--- a/backend/alembic/versions/005_add_monitored_sources.py
+++ b/backend/alembic/versions/005_add_monitored_sources.py
@@ -1,0 +1,52 @@
+"""Add monitored_sources table.
+
+Revision ID: 005
+Revises: 004
+"""
+
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+revision = "005"
+down_revision = "004"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "monitored_sources",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            primary_key=True,
+        ),
+        sa.Column("name", sa.Text(), nullable=False),
+        sa.Column("url", sa.Text(), nullable=False, unique=True),
+        sa.Column("source_type", sa.Text(), nullable=False),
+        sa.Column(
+            "investor_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("investors.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("active", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("last_checked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_monitored_sources_source_type", "monitored_sources", ["source_type"])
+    op.create_index("ix_monitored_sources_active", "monitored_sources", ["active"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_monitored_sources_active", table_name="monitored_sources")
+    op.drop_index("ix_monitored_sources_source_type", table_name="monitored_sources")
+    op.drop_table("monitored_sources")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,6 +9,7 @@ from app.routes.funding_rounds import router as funding_rounds_router
 from app.routes.health import router as health_router
 from app.routes.ingest import router as ingest_router
 from app.routes.investors import router as investors_router
+from app.routes.sources import router as sources_router
 from app.routes.stats import router as stats_router
 
 app = FastAPI(title="StartupTracker API", version="0.1.0")
@@ -27,4 +28,5 @@ app.include_router(companies_router)
 app.include_router(funding_rounds_router)
 app.include_router(ingest_router)
 app.include_router(investors_router)
+app.include_router(sources_router)
 app.include_router(stats_router)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -3,6 +3,7 @@ from app.models.base import Base
 from app.models.company import Company
 from app.models.funding_round import FundingRound
 from app.models.investor import Investor
+from app.models.monitored_source import MonitoredSource
 from app.models.raw_source import RawSource
 from app.models.round_investor import round_investors
 
@@ -12,6 +13,7 @@ __all__ = [
     "Company",
     "FundingRound",
     "Investor",
+    "MonitoredSource",
     "RawSource",
     "round_investors",
 ]

--- a/backend/app/models/monitored_source.py
+++ b/backend/app/models/monitored_source.py
@@ -1,0 +1,26 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, pk_uuid
+
+
+class MonitoredSource(Base, TimestampMixin):
+    __tablename__ = "monitored_sources"
+
+    id: Mapped[uuid.UUID] = pk_uuid()
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    url: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    source_type: Mapped[str] = mapped_column(Text, nullable=False)  # 'rss' or 'webpage'
+    investor_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("investors.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    active: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    last_checked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+
+    investor = relationship("Investor", lazy="selectin")

--- a/backend/app/routes/sources.py
+++ b/backend/app/routes/sources.py
@@ -1,0 +1,85 @@
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.schemas.common import PaginatedResponse
+from app.schemas.monitored_source import (
+    MonitoredSourceCreate,
+    MonitoredSourceResponse,
+    MonitoredSourceUpdate,
+)
+from app.services.crud import (
+    create_monitored_source,
+    get_monitored_source,
+    list_monitored_sources,
+    update_monitored_source,
+)
+from app.services.db import get_session
+
+router = APIRouter(prefix="/sources", tags=["sources"])
+
+
+@router.get("", response_model=PaginatedResponse)
+async def list_sources_endpoint(
+    source_type: str | None = Query(None, description="Filter by source type (rss/webpage)"),
+    active: bool | None = Query(None, description="Filter by active status"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+):
+    sources, total = await list_monitored_sources(
+        session, source_type=source_type, active=active, page=page, page_size=page_size
+    )
+    return PaginatedResponse(
+        items=[MonitoredSourceResponse.model_validate(s) for s in sources],
+        total=total,
+        page=page,
+        page_size=page_size,
+    )
+
+
+@router.get("/{source_id}", response_model=MonitoredSourceResponse)
+async def get_source_endpoint(
+    source_id: uuid.UUID,
+    session: AsyncSession = Depends(get_session),
+):
+    source = await get_monitored_source(session, source_id)
+    if not source:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return MonitoredSourceResponse.model_validate(source)
+
+
+@router.post("", response_model=MonitoredSourceResponse, status_code=201)
+async def create_source_endpoint(
+    body: MonitoredSourceCreate,
+    session: AsyncSession = Depends(get_session),
+):
+    if body.source_type not in ("rss", "webpage"):
+        raise HTTPException(status_code=422, detail="source_type must be 'rss' or 'webpage'")
+    source = await create_monitored_source(
+        session,
+        name=body.name,
+        url=body.url,
+        source_type=body.source_type,
+        investor_id=body.investor_id,
+        active=body.active,
+    )
+    await session.commit()
+    return MonitoredSourceResponse.model_validate(source)
+
+
+@router.patch("/{source_id}", response_model=MonitoredSourceResponse)
+async def update_source_endpoint(
+    source_id: uuid.UUID,
+    body: MonitoredSourceUpdate,
+    session: AsyncSession = Depends(get_session),
+):
+    updates = body.model_dump(exclude_unset=True)
+    if "source_type" in updates and updates["source_type"] not in ("rss", "webpage"):
+        raise HTTPException(status_code=422, detail="source_type must be 'rss' or 'webpage'")
+    source = await update_monitored_source(session, source_id, **updates)
+    if not source:
+        raise HTTPException(status_code=404, detail="Source not found")
+    await session.commit()
+    return MonitoredSourceResponse.model_validate(source)

--- a/backend/app/schemas/monitored_source.py
+++ b/backend/app/schemas/monitored_source.py
@@ -1,0 +1,32 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class MonitoredSourceCreate(BaseModel):
+    name: str
+    url: str
+    source_type: str  # 'rss' or 'webpage'
+    investor_id: uuid.UUID | None = None
+    active: bool = True
+
+
+class MonitoredSourceUpdate(BaseModel):
+    name: str | None = None
+    active: bool | None = None
+    source_type: str | None = None
+    investor_id: uuid.UUID | None = None
+
+
+class MonitoredSourceResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: uuid.UUID
+    name: str
+    url: str
+    source_type: str
+    investor_id: uuid.UUID | None = None
+    active: bool
+    last_checked_at: datetime | None = None
+    created_at: datetime

--- a/backend/app/services/cron_ingest.py
+++ b/backend/app/services/cron_ingest.py
@@ -1,9 +1,10 @@
-"""Cron entry point for batch ingestion of RSS feeds."""
+"""Cron entry point for batch ingestion of RSS feeds and monitored sources."""
 
 import asyncio
 import logging
 import os
 
+from app.services.crud import get_active_sources, mark_source_checked
 from app.services.db import async_session
 from app.services.ingestion import ingest_rss_feed
 
@@ -14,16 +15,28 @@ FEED_URLS = [u.strip() for u in os.environ.get("FEED_URLS", "").split(",") if u.
 
 
 async def main():
-    if not FEED_URLS:
-        logger.warning("No FEED_URLS configured, nothing to ingest")
-        return
-
     async with async_session() as session:
-        for feed_url in FEED_URLS:
-            logger.info("Processing feed: %s", feed_url)
-            results = await ingest_rss_feed(session, feed_url)
-            for r in results:
-                logger.info("  %s -> %s", r["url"], r["status"])
+        # DB-driven sources take priority
+        db_sources = await get_active_sources(session, source_type="rss")
+
+        if db_sources:
+            for source in db_sources:
+                logger.info("Processing DB source: %s (%s)", source.name, source.url)
+                results = await ingest_rss_feed(session, source.url)
+                for r in results:
+                    logger.info("  %s -> %s", r["url"], r["status"])
+                await mark_source_checked(session, source.id)
+                await session.commit()
+        elif FEED_URLS:
+            # Fallback to env var
+            logger.info("No DB sources found, falling back to FEED_URLS env var")
+            for feed_url in FEED_URLS:
+                logger.info("Processing feed: %s", feed_url)
+                results = await ingest_rss_feed(session, feed_url)
+                for r in results:
+                    logger.info("  %s -> %s", r["url"], r["status"])
+        else:
+            logger.warning("No sources configured (DB or FEED_URLS), nothing to ingest")
 
 
 if __name__ == "__main__":

--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -1,5 +1,6 @@
 import re
 import uuid
+from datetime import UTC
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -9,6 +10,7 @@ from app.models.acquisition import Acquisition
 from app.models.company import Company
 from app.models.funding_round import FundingRound
 from app.models.investor import Investor
+from app.models.monitored_source import MonitoredSource
 from app.models.raw_source import RawSource
 from app.models.round_investor import round_investors
 
@@ -397,3 +399,106 @@ async def get_stats(session: AsyncSession) -> dict:
         "total_investors": total_investors,
         "total_funding_usd": float(total_funding),
     }
+
+
+# ---------------------------------------------------------------------------
+# Monitored sources
+# ---------------------------------------------------------------------------
+
+
+async def create_monitored_source(
+    session: AsyncSession,
+    *,
+    name: str,
+    url: str,
+    source_type: str,
+    investor_id: uuid.UUID | None = None,
+    active: bool = True,
+) -> MonitoredSource:
+    ms = MonitoredSource(
+        name=name,
+        url=url,
+        source_type=source_type,
+        investor_id=investor_id,
+        active=active,
+    )
+    session.add(ms)
+    await session.flush()
+    return ms
+
+
+async def get_monitored_source(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> MonitoredSource | None:
+    stmt = select(MonitoredSource).where(MonitoredSource.id == source_id)
+    result = await session.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_monitored_sources(
+    session: AsyncSession,
+    *,
+    source_type: str | None = None,
+    active: bool | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[MonitoredSource], int]:
+    base = select(MonitoredSource)
+    count_base = select(func.count()).select_from(MonitoredSource)
+
+    if source_type:
+        base = base.where(MonitoredSource.source_type == source_type)
+        count_base = count_base.where(MonitoredSource.source_type == source_type)
+    if active is not None:
+        base = base.where(MonitoredSource.active.is_(active))
+        count_base = count_base.where(MonitoredSource.active.is_(active))
+
+    total = (await session.execute(count_base)).scalar_one()
+
+    stmt = base.order_by(MonitoredSource.name).offset((page - 1) * page_size).limit(page_size)
+    rows = (await session.execute(stmt)).scalars().all()
+    return list(rows), total
+
+
+async def update_monitored_source(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+    **kwargs,
+) -> MonitoredSource | None:
+    stmt = select(MonitoredSource).where(MonitoredSource.id == source_id)
+    result = await session.execute(stmt)
+    ms = result.scalar_one_or_none()
+    if not ms:
+        return None
+    for key, value in kwargs.items():
+        if hasattr(ms, key):
+            setattr(ms, key, value)
+    await session.flush()
+    return ms
+
+
+async def get_active_sources(
+    session: AsyncSession,
+    source_type: str | None = None,
+) -> list[MonitoredSource]:
+    stmt = select(MonitoredSource).where(MonitoredSource.active.is_(True))
+    if source_type:
+        stmt = stmt.where(MonitoredSource.source_type == source_type)
+    stmt = stmt.order_by(MonitoredSource.name)
+    rows = (await session.execute(stmt)).scalars().all()
+    return list(rows)
+
+
+async def mark_source_checked(
+    session: AsyncSession,
+    source_id: uuid.UUID,
+) -> None:
+    from datetime import datetime
+
+    stmt = select(MonitoredSource).where(MonitoredSource.id == source_id)
+    result = await session.execute(stmt)
+    ms = result.scalar_one_or_none()
+    if ms:
+        ms.last_checked_at = datetime.now(UTC)
+        await session.flush()

--- a/backend/tests/test_monitored_sources.py
+++ b/backend/tests/test_monitored_sources.py
@@ -1,0 +1,287 @@
+"""Tests for monitored sources CRUD and API."""
+
+import pytest
+
+from app.services.crud import (
+    create_monitored_source,
+    get_active_sources,
+    get_monitored_source,
+    list_monitored_sources,
+    mark_source_checked,
+    update_monitored_source,
+)
+
+
+class TestMonitoredSourcesCRUD:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, session):
+        ms = await create_monitored_source(
+            session,
+            name="TechCrunch",
+            url="https://techcrunch.com/feed/",
+            source_type="rss",
+        )
+        await session.commit()
+
+        fetched = await get_monitored_source(session, ms.id)
+        assert fetched is not None
+        assert fetched.name == "TechCrunch"
+        assert fetched.url == "https://techcrunch.com/feed/"
+        assert fetched.source_type == "rss"
+        assert fetched.active is True
+        assert fetched.last_checked_at is None
+
+    @pytest.mark.asyncio
+    async def test_create_webpage_source(self, session):
+        ms = await create_monitored_source(
+            session,
+            name="a16z Announcements",
+            url="https://a16z.com/announcements/",
+            source_type="webpage",
+        )
+        await session.commit()
+
+        assert ms.source_type == "webpage"
+        assert ms.active is True
+
+    @pytest.mark.asyncio
+    async def test_list_sources(self, session):
+        await create_monitored_source(
+            session, name="Feed A", url="https://a.com/feed", source_type="rss"
+        )
+        await create_monitored_source(
+            session, name="Page B", url="https://b.com/news", source_type="webpage"
+        )
+        await session.commit()
+
+        sources, total = await list_monitored_sources(session)
+        assert total == 2
+        assert len(sources) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_type(self, session):
+        await create_monitored_source(
+            session, name="Feed A", url="https://a.com/feed", source_type="rss"
+        )
+        await create_monitored_source(
+            session, name="Page B", url="https://b.com/news", source_type="webpage"
+        )
+        await session.commit()
+
+        rss_sources, rss_total = await list_monitored_sources(session, source_type="rss")
+        assert rss_total == 1
+        assert rss_sources[0].name == "Feed A"
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_active(self, session):
+        await create_monitored_source(
+            session, name="Active", url="https://a.com/feed", source_type="rss", active=True
+        )
+        await create_monitored_source(
+            session, name="Inactive", url="https://b.com/feed", source_type="rss", active=False
+        )
+        await session.commit()
+
+        active, total = await list_monitored_sources(session, active=True)
+        assert total == 1
+        assert active[0].name == "Active"
+
+    @pytest.mark.asyncio
+    async def test_update_source(self, session):
+        ms = await create_monitored_source(
+            session, name="Old Name", url="https://old.com/feed", source_type="rss"
+        )
+        await session.commit()
+
+        updated = await update_monitored_source(session, ms.id, name="New Name", active=False)
+        assert updated is not None
+        assert updated.name == "New Name"
+        assert updated.active is False
+
+    @pytest.mark.asyncio
+    async def test_update_nonexistent_returns_none(self, session):
+        import uuid
+
+        result = await update_monitored_source(session, uuid.uuid4(), name="Nope")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_active_sources(self, session):
+        await create_monitored_source(
+            session, name="Active RSS", url="https://a.com/feed", source_type="rss"
+        )
+        await create_monitored_source(
+            session, name="Inactive RSS", url="https://b.com/feed", source_type="rss", active=False
+        )
+        await create_monitored_source(
+            session, name="Active Web", url="https://c.com/news", source_type="webpage"
+        )
+        await session.commit()
+
+        all_active = await get_active_sources(session)
+        assert len(all_active) == 2
+
+        rss_active = await get_active_sources(session, source_type="rss")
+        assert len(rss_active) == 1
+        assert rss_active[0].name == "Active RSS"
+
+    @pytest.mark.asyncio
+    async def test_mark_source_checked(self, session):
+        ms = await create_monitored_source(
+            session, name="Feed", url="https://feed.com/rss", source_type="rss"
+        )
+        await session.commit()
+        assert ms.last_checked_at is None
+
+        await mark_source_checked(session, ms.id)
+        await session.commit()
+
+        fetched = await get_monitored_source(session, ms.id)
+        assert fetched.last_checked_at is not None
+
+
+class TestMonitoredSourcesAPI:
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        return TestClient(app)
+
+    @pytest.mark.asyncio
+    async def test_create_source_api(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+
+        resp = client.post(
+            "/sources",
+            json={
+                "name": "TechCrunch",
+                "url": "https://techcrunch.com/feed/",
+                "source_type": "rss",
+            },
+        )
+        assert resp.status_code == 201
+        data = resp.json()
+        assert data["name"] == "TechCrunch"
+        assert data["source_type"] == "rss"
+        assert data["active"] is True
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_create_invalid_source_type(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+
+        resp = client.post(
+            "/sources",
+            json={
+                "name": "Bad",
+                "url": "https://bad.com",
+                "source_type": "invalid",
+            },
+        )
+        assert resp.status_code == 422
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_list_sources_api(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+
+        await create_monitored_source(
+            session, name="Feed", url="https://feed.com/rss", source_type="rss"
+        )
+        await session.commit()
+
+        resp = client.get("/sources")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["name"] == "Feed"
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_get_source_api(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+
+        ms = await create_monitored_source(
+            session, name="Feed", url="https://feed.com/rss", source_type="rss"
+        )
+        await session.commit()
+
+        resp = client.get(f"/sources/{ms.id}")
+        assert resp.status_code == 200
+        assert resp.json()["name"] == "Feed"
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_get_source_not_found(self, client, session):
+        import uuid
+
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+
+        resp = client.get(f"/sources/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_update_source_api(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+
+        ms = await create_monitored_source(
+            session, name="Old", url="https://old.com/rss", source_type="rss"
+        )
+        await session.commit()
+
+        resp = client.patch(f"/sources/{ms.id}", json={"name": "New", "active": False})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "New"
+        assert data["active"] is False
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_list_filter_by_type_api(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+
+        await create_monitored_source(
+            session, name="RSS", url="https://rss.com/feed", source_type="rss"
+        )
+        await create_monitored_source(
+            session, name="Web", url="https://web.com/news", source_type="webpage"
+        )
+        await session.commit()
+
+        resp = client.get("/sources?source_type=rss")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["total"] == 1
+        assert data["items"][0]["name"] == "RSS"
+
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- New `monitored_sources` table with Alembic migration (005) - stores RSS feeds and VC webpage URLs with active/inactive toggling
- CRUD operations: create, get, list (filterable by type/active), update, get_active_sources, mark_source_checked
- REST API: GET/POST /sources, GET/PATCH /sources/{id} with source_type validation
- Updated cron_ingest.py to read from DB first, falling back to FEED_URLS env var
- 16 new tests (9 CRUD + 7 API), 216 total passing

## Test plan
- [x] All 216 tests pass
- [x] Ruff lint + format clean
- [ ] CI passes

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)