### PR TITLE
Add webpage link discovery for VC press pages

### DIFF
--- a/backend/app/services/cron_ingest.py
+++ b/backend/app/services/cron_ingest.py
@@ -1,4 +1,4 @@
-"""Cron entry point for batch ingestion of RSS feeds and monitored sources."""
+"""Cron entry point for batch ingestion of RSS feeds and webpage sources."""
 
 import asyncio
 import logging
@@ -6,7 +6,7 @@ import os
 
 from app.services.crud import get_active_sources, mark_source_checked
 from app.services.db import async_session
-from app.services.ingestion import ingest_rss_feed
+from app.services.ingestion import ingest_rss_feed, ingest_webpage_source
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -17,12 +17,24 @@ FEED_URLS = [u.strip() for u in os.environ.get("FEED_URLS", "").split(",") if u.
 async def main():
     async with async_session() as session:
         # DB-driven sources take priority
-        db_sources = await get_active_sources(session, source_type="rss")
+        db_sources = await get_active_sources(session)
 
         if db_sources:
             for source in db_sources:
-                logger.info("Processing DB source: %s (%s)", source.name, source.url)
-                results = await ingest_rss_feed(session, source.url)
+                logger.info(
+                    "Processing %s source: %s (%s)",
+                    source.source_type,
+                    source.name,
+                    source.url,
+                )
+                if source.source_type == "rss":
+                    results = await ingest_rss_feed(session, source.url)
+                elif source.source_type == "webpage":
+                    results = await ingest_webpage_source(session, source.url)
+                else:
+                    logger.warning("Unknown source type: %s", source.source_type)
+                    continue
+
                 for r in results:
                     logger.info("  %s -> %s", r["url"], r["status"])
                 await mark_source_checked(session, source.id)

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -19,6 +19,7 @@ from app.services.dedup import (
     is_duplicate_round,
 )
 from app.services.fetcher import fetch_article_text, parse_rss_feed
+from app.services.link_discovery import discover_links
 from app.services.llm import extract_article
 from app.services.normalization import (
     validate_acquisition_extraction,
@@ -186,6 +187,30 @@ async def ingest_rss_feed(
 ) -> list[dict]:
     """Parse an RSS feed and ingest all new articles."""
     entries = await parse_rss_feed(feed_url)
+    results = []
+
+    for entry in entries:
+        url = entry["url"]
+        title = entry.get("title")
+
+        # Skip already-processed URLs
+        existing = await get_raw_source_by_url(session, url)
+        if existing and existing.processed:
+            results.append({"url": url, "status": "already_processed"})
+            continue
+
+        result = await ingest_url(session, url, title=title)
+        results.append(result)
+
+    return results
+
+
+async def ingest_webpage_source(
+    session: AsyncSession,
+    page_url: str,
+) -> list[dict]:
+    """Discover links from a webpage and ingest new articles."""
+    entries = await discover_links(page_url)
     results = []
 
     for entry in entries:

--- a/backend/app/services/link_discovery.py
+++ b/backend/app/services/link_discovery.py
@@ -1,0 +1,130 @@
+"""Discover article links from VC firm press/news pages."""
+
+import logging
+import re
+from urllib.parse import urljoin, urlparse
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+# URL path patterns that suggest an article or press release
+ARTICLE_PATTERNS = [
+    re.compile(r"/blog/"),
+    re.compile(r"/press/"),
+    re.compile(r"/news/"),
+    re.compile(r"/announcements?/"),
+    re.compile(r"/perspectives?/"),
+    re.compile(r"/noteworthy/"),
+    re.compile(r"/newsroom/"),
+    re.compile(r"/portfolio/"),
+    re.compile(r"/20\d{2}/"),  # Year in URL (2000-2099)
+]
+
+# Paths to exclude (navigation, assets, etc.)
+EXCLUDE_PATTERNS = [
+    re.compile(r"\.(css|js|png|jpg|jpeg|gif|svg|ico|woff|pdf)(\?|$)", re.IGNORECASE),
+    re.compile(r"/(login|signup|register|contact|about|careers|privacy|terms)(/|$)"),
+    re.compile(r"^#"),
+    re.compile(r"^mailto:"),
+    re.compile(r"^javascript:"),
+]
+
+
+def _is_article_url(url: str, base_domain: str) -> bool:
+    """Check if a URL looks like an article based on path heuristics."""
+    parsed = urlparse(url)
+
+    # Must be same domain or subdomain
+    if not parsed.netloc.endswith(base_domain):
+        return False
+
+    path = parsed.path.lower()
+
+    # Exclude non-article resources
+    for pattern in EXCLUDE_PATTERNS:
+        if pattern.search(url):
+            return False
+
+    # Must not be the root or a very short path
+    if len(path.rstrip("/")) < 5:
+        return False
+
+    # Check article patterns
+    for pattern in ARTICLE_PATTERNS:
+        if pattern.search(path):
+            return True
+
+    return False
+
+
+def _extract_base_domain(url: str) -> str:
+    """Extract the base domain from a URL (e.g., 'a16z.com' from 'https://a16z.com/path')."""
+    parsed = urlparse(url)
+    parts = parsed.netloc.split(".")
+    # Handle cases like www.example.com -> example.com
+    if len(parts) > 2 and parts[0] == "www":
+        return ".".join(parts[1:])
+    return parsed.netloc
+
+
+async def discover_links(page_url: str, max_links: int = 50) -> list[dict[str, str]]:
+    """Fetch a webpage and extract article-like links.
+
+    Returns a list of {url, title} dicts, similar to parse_rss_feed output.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=20, follow_redirects=True) as client:
+            resp = await client.get(page_url, headers={"User-Agent": "StartupTracker/0.1"})
+            resp.raise_for_status()
+            html = resp.text
+    except httpx.HTTPError as e:
+        logger.warning("Failed to fetch page %s: %s", page_url, e)
+        return []
+
+    return extract_links_from_html(html, page_url, max_links)
+
+
+def extract_links_from_html(html: str, base_url: str, max_links: int = 50) -> list[dict[str, str]]:
+    """Extract article-like links from HTML content."""
+    base_domain = _extract_base_domain(base_url)
+
+    # Simple regex to find <a> tags with href
+    link_pattern = re.compile(
+        r'<a\s[^>]*href=["\']([^"\']+)["\'][^>]*>(.*?)</a>',
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    seen_urls: set[str] = set()
+    results: list[dict[str, str]] = []
+
+    for match in link_pattern.finditer(html):
+        href = match.group(1).strip()
+        raw_title = match.group(2).strip()
+
+        # Resolve relative URLs
+        full_url = urljoin(base_url, href)
+
+        # Normalize
+        parsed = urlparse(full_url)
+        normalized = f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+        normalized = normalized.rstrip("/")
+
+        if normalized in seen_urls:
+            continue
+
+        if not _is_article_url(full_url, base_domain):
+            continue
+
+        seen_urls.add(normalized)
+
+        # Clean title: strip HTML tags
+        title = re.sub(r"<[^>]+>", "", raw_title).strip()
+        title = re.sub(r"\s+", " ", title)
+
+        results.append({"url": full_url, "title": title or None})
+
+        if len(results) >= max_links:
+            break
+
+    return results

--- a/backend/tests/test_link_discovery.py
+++ b/backend/tests/test_link_discovery.py
@@ -1,0 +1,141 @@
+"""Tests for the link discovery service."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.link_discovery import (
+    _extract_base_domain,
+    _is_article_url,
+    discover_links,
+    extract_links_from_html,
+)
+
+
+class TestExtractBaseDomain:
+    def test_simple_domain(self):
+        assert _extract_base_domain("https://a16z.com/announcements/") == "a16z.com"
+
+    def test_www_prefix(self):
+        assert _extract_base_domain("https://www.sequoiacap.com/build/") == "sequoiacap.com"
+
+    def test_subdomain(self):
+        assert _extract_base_domain("https://news.crunchbase.com/feed/") == "news.crunchbase.com"
+
+
+class TestIsArticleUrl:
+    def test_blog_url(self):
+        assert _is_article_url("https://a16z.com/blog/some-article", "a16z.com") is True
+
+    def test_news_url(self):
+        assert _is_article_url("https://a16z.com/news/funding-round", "a16z.com") is True
+
+    def test_year_url(self):
+        assert _is_article_url("https://a16z.com/2026/03/article", "a16z.com") is True
+
+    def test_press_url(self):
+        assert _is_article_url("https://a16z.com/press/new-fund", "a16z.com") is True
+
+    def test_announcements_url(self):
+        url = "https://a16z.com/announcements/series-b"
+        assert _is_article_url(url, "a16z.com") is True
+
+    def test_different_domain_rejected(self):
+        assert _is_article_url("https://other.com/blog/article", "a16z.com") is False
+
+    def test_root_url_rejected(self):
+        assert _is_article_url("https://a16z.com/", "a16z.com") is False
+
+    def test_asset_url_rejected(self):
+        assert _is_article_url("https://a16z.com/blog/image.png", "a16z.com") is False
+
+    def test_login_rejected(self):
+        assert _is_article_url("https://a16z.com/login/", "a16z.com") is False
+
+    def test_short_path_rejected(self):
+        assert _is_article_url("https://a16z.com/ab", "a16z.com") is False
+
+    def test_no_article_pattern(self):
+        assert _is_article_url("https://a16z.com/team/partner", "a16z.com") is False
+
+
+class TestExtractLinksFromHtml:
+    def test_extracts_article_links(self):
+        html = """
+        <html><body>
+        <a href="/blog/series-a-announcement">Series A for TestCo</a>
+        <a href="/blog/market-outlook-2026">Market Outlook 2026</a>
+        <a href="/about">About Us</a>
+        </body></html>
+        """
+        results = extract_links_from_html(html, "https://a16z.com/announcements/")
+        assert len(results) == 2
+        assert results[0]["url"] == "https://a16z.com/blog/series-a-announcement"
+        assert results[0]["title"] == "Series A for TestCo"
+
+    def test_deduplicates_links(self):
+        html = """
+        <a href="/blog/article-1">First</a>
+        <a href="/blog/article-1">Duplicate</a>
+        """
+        results = extract_links_from_html(html, "https://example.com/news/")
+        assert len(results) == 1
+
+    def test_resolves_relative_urls(self):
+        html = '<a href="/news/funding">Funding News</a>'
+        results = extract_links_from_html(html, "https://example.com/press/")
+        assert results[0]["url"] == "https://example.com/news/funding"
+
+    def test_respects_max_links(self):
+        links = "".join(f'<a href="/blog/article-{i}">Article {i}</a>' for i in range(100))
+        html = f"<html><body>{links}</body></html>"
+        results = extract_links_from_html(html, "https://example.com/", max_links=5)
+        assert len(results) == 5
+
+    def test_strips_html_from_title(self):
+        html = '<a href="/blog/test"><span class="bold">Bold Title</span></a>'
+        results = extract_links_from_html(html, "https://example.com/")
+        assert results[0]["title"] == "Bold Title"
+
+    def test_empty_html(self):
+        results = extract_links_from_html("", "https://example.com/")
+        assert results == []
+
+    def test_no_matching_links(self):
+        html = '<a href="/about">About</a><a href="/contact">Contact</a>'
+        results = extract_links_from_html(html, "https://example.com/")
+        assert results == []
+
+
+class TestDiscoverLinks:
+    @pytest.mark.asyncio
+    async def test_successful_discovery(self):
+        html = '<a href="/blog/new-fund">New Fund Announcement</a>'
+        mock_resp = AsyncMock()
+        mock_resp.text = html
+        mock_resp.raise_for_status = lambda: None
+
+        with patch("app.services.link_discovery.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_client.return_value.get = AsyncMock(return_value=mock_resp)
+
+            results = await discover_links("https://a16z.com/announcements/")
+
+        assert len(results) == 1
+        assert results[0]["title"] == "New Fund Announcement"
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_returns_empty(self):
+        import httpx
+
+        with patch("app.services.link_discovery.httpx.AsyncClient") as mock_client:
+            mock_client.return_value.__aenter__ = AsyncMock(return_value=mock_client.return_value)
+            mock_client.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_client.return_value.get = AsyncMock(
+                side_effect=httpx.HTTPError("Connection failed")
+            )
+
+            results = await discover_links("https://broken.com/news/")
+
+        assert results == []


### PR DESCRIPTION
## Summary
- New `link_discovery.py` service: extracts article-like links from VC firm webpages using URL path heuristics (blog, press, news, year patterns)
- New `ingest_webpage_source()` in ingestion pipeline for processing discovered links
- Updated `cron_ingest.py` to handle both `rss` and `webpage` source types from the monitored_sources table
- 23 new tests covering URL pattern matching, link extraction, dedup, and async discovery

## Test plan
- [x] All 239 tests pass
- [x] Ruff lint + format clean
- [ ] CI passes

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)