### PR TITLE
Add analytics endpoints for charts and aggregations

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -4,6 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.routes.acquisitions import router as acquisitions_router
+from app.routes.analytics import router as analytics_router
 from app.routes.companies import router as companies_router
 from app.routes.funding_rounds import router as funding_rounds_router
 from app.routes.health import router as health_router
@@ -24,6 +25,7 @@ app.add_middleware(
 
 app.include_router(health_router)
 app.include_router(acquisitions_router)
+app.include_router(analytics_router)
 app.include_router(companies_router)
 app.include_router(funding_rounds_router)
 app.include_router(ingest_router)

--- a/backend/app/routes/analytics.py
+++ b/backend/app/routes/analytics.py
@@ -1,0 +1,68 @@
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.services.analytics import (
+    acquisitions_summary,
+    co_investor_pairs,
+    funding_by_month,
+    funding_by_sector,
+    round_type_distribution,
+    sector_summary,
+    top_investors,
+)
+from app.services.db import get_session
+
+router = APIRouter(prefix="/analytics", tags=["analytics"])
+
+
+@router.get("/funding-by-sector")
+async def funding_by_sector_endpoint(
+    session: AsyncSession = Depends(get_session),
+):
+    return await funding_by_sector(session)
+
+
+@router.get("/funding-by-month")
+async def funding_by_month_endpoint(
+    sector: str | None = Query(None, description="Filter by sector"),
+    months: int = Query(12, ge=1, le=60, description="Number of months to look back"),
+    session: AsyncSession = Depends(get_session),
+):
+    return await funding_by_month(session, sector=sector, months=months)
+
+
+@router.get("/top-investors")
+async def top_investors_endpoint(
+    limit: int = Query(20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+):
+    return await top_investors(session, limit=limit)
+
+
+@router.get("/co-investors")
+async def co_investors_endpoint(
+    limit: int = Query(20, ge=1, le=100),
+    session: AsyncSession = Depends(get_session),
+):
+    return await co_investor_pairs(session, limit=limit)
+
+
+@router.get("/sector-summary")
+async def sector_summary_endpoint(
+    session: AsyncSession = Depends(get_session),
+):
+    return await sector_summary(session)
+
+
+@router.get("/acquisitions-summary")
+async def acquisitions_summary_endpoint(
+    session: AsyncSession = Depends(get_session),
+):
+    return await acquisitions_summary(session)
+
+
+@router.get("/round-type-distribution")
+async def round_type_distribution_endpoint(
+    session: AsyncSession = Depends(get_session),
+):
+    return await round_type_distribution(session)

--- a/backend/app/services/analytics.py
+++ b/backend/app/services/analytics.py
@@ -1,0 +1,211 @@
+"""Analytics aggregation queries for charts and dashboards."""
+
+from datetime import date, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.acquisition import Acquisition
+from app.models.company import Company
+from app.models.funding_round import FundingRound
+from app.models.investor import Investor
+from app.models.round_investor import round_investors
+
+
+async def funding_by_sector(session: AsyncSession) -> list[dict]:
+    """Total funding amount and round count grouped by sector."""
+    stmt = (
+        select(
+            Company.sector,
+            func.count(FundingRound.id).label("round_count"),
+            func.coalesce(func.sum(FundingRound.amount_usd), 0).label("total_amount"),
+        )
+        .join(FundingRound, FundingRound.company_id == Company.id)
+        .where(Company.sector.isnot(None))
+        .group_by(Company.sector)
+        .order_by(func.sum(FundingRound.amount_usd).desc().nullslast())
+    )
+    rows = (await session.execute(stmt)).all()
+    return [
+        {"sector": r.sector, "round_count": r.round_count, "total_amount": float(r.total_amount)}
+        for r in rows
+    ]
+
+
+async def funding_by_month(
+    session: AsyncSession,
+    *,
+    sector: str | None = None,
+    months: int = 12,
+) -> list[dict]:
+    """Funding time series grouped by month."""
+    cutoff = date.today() - timedelta(days=months * 30)
+
+    base = (
+        select(
+            func.date_trunc("month", FundingRound.announced_date).label("month"),
+            func.count(FundingRound.id).label("round_count"),
+            func.coalesce(func.sum(FundingRound.amount_usd), 0).label("total_amount"),
+        )
+        .where(FundingRound.announced_date.isnot(None))
+        .where(FundingRound.announced_date >= cutoff)
+    )
+
+    if sector:
+        base = base.join(Company, Company.id == FundingRound.company_id).where(
+            Company.sector == sector
+        )
+
+    stmt = base.group_by("month").order_by("month")
+    rows = (await session.execute(stmt)).all()
+    return [
+        {
+            "month": r.month.isoformat() if r.month else None,
+            "round_count": r.round_count,
+            "total_amount": float(r.total_amount),
+        }
+        for r in rows
+    ]
+
+
+async def top_investors(
+    session: AsyncSession,
+    *,
+    limit: int = 20,
+) -> list[dict]:
+    """Top investors ranked by deal count and total invested."""
+    stmt = (
+        select(
+            Investor.id,
+            Investor.name,
+            func.count(round_investors.c.round_id).label("deal_count"),
+            func.coalesce(func.sum(FundingRound.amount_usd), 0).label("total_invested"),
+        )
+        .join(round_investors, round_investors.c.investor_id == Investor.id)
+        .join(FundingRound, FundingRound.id == round_investors.c.round_id)
+        .group_by(Investor.id, Investor.name)
+        .order_by(func.count(round_investors.c.round_id).desc())
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).all()
+    return [
+        {
+            "id": str(r.id),
+            "name": r.name,
+            "deal_count": r.deal_count,
+            "total_invested": float(r.total_invested),
+        }
+        for r in rows
+    ]
+
+
+async def co_investor_pairs(
+    session: AsyncSession,
+    *,
+    limit: int = 20,
+) -> list[dict]:
+    """Most frequent co-investor pairs (self-join on round_investors)."""
+    ri1 = round_investors.alias("ri1")
+    ri2 = round_investors.alias("ri2")
+    inv1 = Investor.__table__.alias("inv1")
+    inv2 = Investor.__table__.alias("inv2")
+
+    stmt = (
+        select(
+            inv1.c.name.label("investor_a"),
+            inv2.c.name.label("investor_b"),
+            func.count().label("shared_deals"),
+        )
+        .select_from(ri1)
+        .join(ri2, (ri1.c.round_id == ri2.c.round_id) & (ri1.c.investor_id < ri2.c.investor_id))
+        .join(inv1, inv1.c.id == ri1.c.investor_id)
+        .join(inv2, inv2.c.id == ri2.c.investor_id)
+        .group_by(inv1.c.name, inv2.c.name)
+        .order_by(func.count().desc())
+        .limit(limit)
+    )
+    rows = (await session.execute(stmt)).all()
+    return [
+        {
+            "investor_a": r.investor_a,
+            "investor_b": r.investor_b,
+            "shared_deals": r.shared_deals,
+        }
+        for r in rows
+    ]
+
+
+async def sector_summary(session: AsyncSession) -> list[dict]:
+    """Per-sector stats: company count, round count, total funding, avg round size."""
+    stmt = (
+        select(
+            Company.sector,
+            func.count(func.distinct(Company.id)).label("company_count"),
+            func.count(FundingRound.id).label("round_count"),
+            func.coalesce(func.sum(FundingRound.amount_usd), 0).label("total_funding"),
+            func.coalesce(func.avg(FundingRound.amount_usd), 0).label("avg_round_size"),
+        )
+        .outerjoin(FundingRound, FundingRound.company_id == Company.id)
+        .where(Company.sector.isnot(None))
+        .group_by(Company.sector)
+        .order_by(func.count(func.distinct(Company.id)).desc())
+    )
+    rows = (await session.execute(stmt)).all()
+    return [
+        {
+            "sector": r.sector,
+            "company_count": r.company_count,
+            "round_count": r.round_count,
+            "total_funding": float(r.total_funding),
+            "avg_round_size": float(r.avg_round_size),
+        }
+        for r in rows
+    ]
+
+
+async def acquisitions_summary(session: AsyncSession) -> list[dict]:
+    """Top acquirers by acquisition count."""
+    stmt = (
+        select(
+            Company.id,
+            Company.name,
+            func.count(Acquisition.id).label("acquisition_count"),
+            func.coalesce(func.sum(Acquisition.amount_usd), 0).label("total_spent"),
+        )
+        .join(Acquisition, Acquisition.acquirer_id == Company.id)
+        .group_by(Company.id, Company.name)
+        .order_by(func.count(Acquisition.id).desc())
+        .limit(20)
+    )
+    rows = (await session.execute(stmt)).all()
+    return [
+        {
+            "id": str(r.id),
+            "name": r.name,
+            "acquisition_count": r.acquisition_count,
+            "total_spent": float(r.total_spent),
+        }
+        for r in rows
+    ]
+
+
+async def round_type_distribution(session: AsyncSession) -> list[dict]:
+    """Distribution of funding rounds by type."""
+    stmt = (
+        select(
+            FundingRound.round_type,
+            func.count(FundingRound.id).label("count"),
+            func.coalesce(func.sum(FundingRound.amount_usd), 0).label("total_amount"),
+        )
+        .group_by(FundingRound.round_type)
+        .order_by(func.count(FundingRound.id).desc())
+    )
+    rows = (await session.execute(stmt)).all()
+    return [
+        {
+            "round_type": r.round_type,
+            "count": r.count,
+            "total_amount": float(r.total_amount),
+        }
+        for r in rows
+    ]

--- a/backend/tests/test_analytics.py
+++ b/backend/tests/test_analytics.py
@@ -1,0 +1,301 @@
+"""Tests for analytics service and API endpoints."""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from app.services.analytics import (
+    acquisitions_summary,
+    co_investor_pairs,
+    funding_by_sector,
+    round_type_distribution,
+    sector_summary,
+    top_investors,
+)
+from app.services.crud import (
+    create_acquisition,
+    create_company,
+    create_funding_round,
+    create_investor,
+)
+
+
+async def _seed_data(session):
+    """Create test data for analytics queries."""
+    # Companies with sectors
+    c1 = await create_company(session, "AlphaAI", sector="AI/ML")
+    c2 = await create_company(session, "BetaFin", sector="Fintech")
+    c3 = await create_company(session, "GammaAI", sector="AI/ML")
+
+    # Investors
+    inv1 = await create_investor(session, "Fund One")
+    inv2 = await create_investor(session, "Fund Two")
+    inv3 = await create_investor(session, "Fund Three")
+
+    # Funding rounds
+    await create_funding_round(
+        session,
+        company_id=c1.id,
+        round_type="Seed",
+        amount_usd=Decimal("1000000"),
+        announced_date=date(2026, 1, 15),
+        investor_ids=[inv1.id, inv2.id],
+    )
+    await create_funding_round(
+        session,
+        company_id=c1.id,
+        round_type="Series A",
+        amount_usd=Decimal("5000000"),
+        announced_date=date(2026, 2, 10),
+        investor_ids=[inv1.id, inv3.id],
+    )
+    await create_funding_round(
+        session,
+        company_id=c2.id,
+        round_type="Series A",
+        amount_usd=Decimal("3000000"),
+        announced_date=date(2026, 2, 20),
+        investor_ids=[inv2.id],
+    )
+    await create_funding_round(
+        session,
+        company_id=c3.id,
+        round_type="Seed",
+        amount_usd=Decimal("2000000"),
+        announced_date=date(2026, 3, 1),
+        investor_ids=[inv1.id, inv2.id, inv3.id],
+    )
+
+    # Acquisition
+    await create_acquisition(
+        session,
+        acquirer_id=c2.id,
+        target_id=c3.id,
+        amount_usd=Decimal("10000000"),
+        announced_date=date(2026, 3, 15),
+    )
+
+    await session.commit()
+    return {"companies": [c1, c2, c3], "investors": [inv1, inv2, inv3]}
+
+
+class TestFundingBySector:
+    @pytest.mark.asyncio
+    async def test_groups_by_sector(self, session):
+        await _seed_data(session)
+        results = await funding_by_sector(session)
+
+        assert len(results) == 2
+        sectors = {r["sector"] for r in results}
+        assert sectors == {"AI/ML", "Fintech"}
+
+    @pytest.mark.asyncio
+    async def test_correct_totals(self, session):
+        await _seed_data(session)
+        results = await funding_by_sector(session)
+
+        ai_ml = next(r for r in results if r["sector"] == "AI/ML")
+        assert ai_ml["round_count"] == 3  # Seed + Series A (AlphaAI) + Seed (GammaAI)
+        assert ai_ml["total_amount"] == 8000000.0
+
+        fintech = next(r for r in results if r["sector"] == "Fintech")
+        assert fintech["round_count"] == 1
+        assert fintech["total_amount"] == 3000000.0
+
+    @pytest.mark.asyncio
+    async def test_empty_db(self, session):
+        results = await funding_by_sector(session)
+        assert results == []
+
+
+class TestTopInvestors:
+    @pytest.mark.asyncio
+    async def test_ranks_by_deal_count(self, session):
+        await _seed_data(session)
+        results = await top_investors(session)
+
+        assert len(results) == 3
+        # Fund One has 3 deals, Fund Two has 3 deals, Fund Three has 2 deals
+        names = [r["name"] for r in results]
+        assert "Fund Three" in names  # least deals, should be last
+        assert results[-1]["deal_count"] <= results[0]["deal_count"]
+
+    @pytest.mark.asyncio
+    async def test_limit(self, session):
+        await _seed_data(session)
+        results = await top_investors(session, limit=1)
+        assert len(results) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_db(self, session):
+        results = await top_investors(session)
+        assert results == []
+
+
+class TestCoInvestorPairs:
+    @pytest.mark.asyncio
+    async def test_finds_co_investors(self, session):
+        await _seed_data(session)
+        results = await co_investor_pairs(session)
+
+        # Fund One + Fund Two co-invest in: AlphaAI Seed, GammaAI Seed = 2 deals
+        # Fund One + Fund Three co-invest in: AlphaAI Series A, GammaAI Seed = 2 deals
+        # Fund Two + Fund Three co-invest in: GammaAI Seed = 1 deal
+        assert len(results) == 3
+        assert results[0]["shared_deals"] >= results[-1]["shared_deals"]
+
+    @pytest.mark.asyncio
+    async def test_empty_db(self, session):
+        results = await co_investor_pairs(session)
+        assert results == []
+
+
+class TestSectorSummary:
+    @pytest.mark.asyncio
+    async def test_includes_all_sectors(self, session):
+        await _seed_data(session)
+        results = await sector_summary(session)
+
+        assert len(results) == 2
+        ai_ml = next(r for r in results if r["sector"] == "AI/ML")
+        assert ai_ml["company_count"] == 2
+        assert ai_ml["round_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_empty_db(self, session):
+        results = await sector_summary(session)
+        assert results == []
+
+
+class TestAcquisitionsSummary:
+    @pytest.mark.asyncio
+    async def test_lists_acquirers(self, session):
+        await _seed_data(session)
+        results = await acquisitions_summary(session)
+
+        assert len(results) == 1
+        assert results[0]["name"] == "BetaFin"
+        assert results[0]["acquisition_count"] == 1
+        assert results[0]["total_spent"] == 10000000.0
+
+    @pytest.mark.asyncio
+    async def test_empty_db(self, session):
+        results = await acquisitions_summary(session)
+        assert results == []
+
+
+class TestRoundTypeDistribution:
+    @pytest.mark.asyncio
+    async def test_distribution(self, session):
+        await _seed_data(session)
+        results = await round_type_distribution(session)
+
+        types = {r["round_type"]: r for r in results}
+        assert "Seed" in types
+        assert "Series A" in types
+        assert types["Seed"]["count"] == 2
+        assert types["Series A"]["count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_empty_db(self, session):
+        results = await round_type_distribution(session)
+        assert results == []
+
+
+class TestAnalyticsAPI:
+    @pytest.fixture
+    def client(self):
+        from fastapi.testclient import TestClient
+
+        from app.main import app
+
+        return TestClient(app)
+
+    @pytest.mark.asyncio
+    async def test_funding_by_sector_endpoint(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+        await _seed_data(session)
+
+        resp = client.get("/analytics/funding-by-sector")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_top_investors_endpoint(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+        await _seed_data(session)
+
+        resp = client.get("/analytics/top-investors?limit=2")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_co_investors_endpoint(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+        await _seed_data(session)
+
+        resp = client.get("/analytics/co-investors")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 3
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_sector_summary_endpoint(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+        await _seed_data(session)
+
+        resp = client.get("/analytics/sector-summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_acquisitions_summary_endpoint(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+        await _seed_data(session)
+
+        resp = client.get("/analytics/acquisitions-summary")
+        assert resp.status_code == 200
+
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_round_type_distribution_endpoint(self, client, session):
+        from app.main import app
+        from app.services.db import get_session
+
+        app.dependency_overrides[get_session] = lambda: session
+        await _seed_data(session)
+
+        resp = client.get("/analytics/round-type-distribution")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 2
+
+        app.dependency_overrides.clear()


### PR DESCRIPTION
## Summary
- New `analytics.py` service with 7 aggregation queries: funding-by-sector, funding-by-month, top-investors, co-investor-pairs, sector-summary, acquisitions-summary, round-type-distribution
- New `/analytics/*` REST endpoints with query params (sector filter, months lookback, limit)
- 20 new tests (14 service + 6 API), 236 total passing

## Test plan
- [x] All 236 tests pass
- [x] Ruff lint + format clean
- [ ] CI passes

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)