### PR TITLE
Update frontend types, API client, and sector display

### DIFF
--- a/frontend/src/app/companies/[id]/page.tsx
+++ b/frontend/src/app/companies/[id]/page.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { RoundBadge } from "@/components/ui/badge";
+import { SectorBadge } from "@/components/ui/sector-badge";
 import { getCompany } from "@/lib/api";
 import { formatUSD, formatDate } from "@/lib/format";
 
@@ -66,6 +67,11 @@ export default async function CompanyDetailPage({ params }: PageProps) {
               <h1 className="text-2xl font-bold text-gray-900">
                 {company.name}
               </h1>
+              {company.sector && (
+                <div className="mt-1">
+                  <SectorBadge sector={company.sector} />
+                </div>
+              )}
               {company.website && (
                 <a
                   href={company.website}
@@ -156,6 +162,20 @@ export default async function CompanyDetailPage({ params }: PageProps) {
                               {inv.name}
                             </span>
                           ))}
+                        </div>
+                      )}
+
+                      {round.confidence_score != null && (
+                        <div className="mt-2 flex items-center gap-1.5">
+                          <div className="h-1.5 w-16 rounded-full bg-gray-200">
+                            <div
+                              className="h-1.5 rounded-full bg-green-500"
+                              style={{ width: `${Math.round(round.confidence_score * 100)}%` }}
+                            />
+                          </div>
+                          <span className="text-xs text-gray-400">
+                            {Math.round(round.confidence_score * 100)}% confidence
+                          </span>
                         </div>
                       )}
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from "react";
 import Link from "next/link";
 import { Building2, TrendingUp, Users, DollarSign, Globe } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { SectorBadge } from "@/components/ui/sector-badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import SearchBar from "@/components/SearchBar";
 import Pagination from "@/components/Pagination";
@@ -100,6 +101,11 @@ function CompanyCard({ company }: { company: Company }) {
             <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
               {company.name}
             </h3>
+            {company.sector && (
+              <div className="mt-1">
+                <SectorBadge sector={company.sector} />
+              </div>
+            )}
             {company.website && (
               <p className="mt-0.5 flex items-center gap-1 text-sm text-gray-400 truncate">
                 <Globe className="h-3 w-3" />

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -10,13 +10,17 @@ import {
   Menu,
   X,
   BarChart3,
+  Handshake,
+  PieChart,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 const NAV_ITEMS = [
   { href: "/", label: "Companies", icon: Building2 },
   { href: "/funding-rounds", label: "Funding Rounds", icon: TrendingUp },
+  { href: "/acquisitions", label: "Acquisitions", icon: Handshake },
   { href: "/investors", label: "Investors", icon: Users },
+  { href: "/analytics", label: "Analytics", icon: PieChart },
 ];
 
 export default function Nav() {

--- a/frontend/src/components/ui/sector-badge.tsx
+++ b/frontend/src/components/ui/sector-badge.tsx
@@ -1,0 +1,36 @@
+import { cn } from "@/lib/utils";
+
+const SECTOR_COLORS: Record<string, string> = {
+  "AI/ML": "bg-violet-100 text-violet-700",
+  "Fintech": "bg-emerald-100 text-emerald-700",
+  "Healthcare/Biotech": "bg-rose-100 text-rose-700",
+  "SaaS/Enterprise": "bg-blue-100 text-blue-700",
+  "E-Commerce/Retail": "bg-orange-100 text-orange-700",
+  "Climate/Energy": "bg-green-100 text-green-700",
+  "Cybersecurity": "bg-red-100 text-red-700",
+  "EdTech": "bg-yellow-100 text-yellow-700",
+  "Real Estate/PropTech": "bg-amber-100 text-amber-700",
+  "Transportation/Logistics": "bg-cyan-100 text-cyan-700",
+  "Media/Entertainment": "bg-pink-100 text-pink-700",
+  "Food/Agriculture": "bg-lime-100 text-lime-700",
+  "Hardware/Robotics": "bg-slate-100 text-slate-700",
+  "Crypto/Web3": "bg-indigo-100 text-indigo-700",
+  "Other": "bg-gray-100 text-gray-700",
+};
+
+export function SectorBadge({ sector }: { sector: string | null }) {
+  if (!sector) return null;
+
+  const colorClass = SECTOR_COLORS[sector] || "bg-gray-100 text-gray-700";
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        colorClass
+      )}
+    >
+      {sector}
+    </span>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,10 +1,18 @@
 import type {
+  Acquisition,
+  AcquisitionSummary,
+  CoInvestorPair,
   Company,
   CompanyDetail,
+  FundingByMonth,
+  FundingBySector,
   FundingRound,
   Investor,
   PaginatedResponse,
+  RoundTypeDistribution,
+  SectorSummary,
   Stats,
+  TopInvestor,
 } from "./types";
 
 const API_BASE = process.env.NEXT_PUBLIC_API_URL || "http://localhost:8000";
@@ -29,8 +37,12 @@ function buildQuery(params: Record<string, string | number | undefined>) {
   return qs ? `?${qs}` : "";
 }
 
+// Companies
 export async function getCompanies(params?: {
   search?: string;
+  sector?: string;
+  sort_by?: string;
+  sort_order?: string;
   page?: number;
   page_size?: number;
 }): Promise<PaginatedResponse<Company>> {
@@ -41,23 +53,86 @@ export async function getCompany(id: string): Promise<CompanyDetail> {
   return fetchApi(`/companies/${id}`);
 }
 
+// Funding Rounds
 export async function getFundingRounds(params?: {
   company_id?: string;
   round_type?: string;
+  investor_id?: string;
+  min_amount?: number;
+  max_amount?: number;
+  date_from?: string;
+  date_to?: string;
+  sort_by?: string;
+  sort_order?: string;
   page?: number;
   page_size?: number;
 }): Promise<PaginatedResponse<FundingRound>> {
   return fetchApi(`/funding-rounds${buildQuery(params || {})}`);
 }
 
+// Investors
 export async function getInvestors(params?: {
   search?: string;
+  investor_type?: string;
+  sort_by?: string;
+  sort_order?: string;
   page?: number;
   page_size?: number;
 }): Promise<PaginatedResponse<Investor>> {
   return fetchApi(`/investors${buildQuery(params || {})}`);
 }
 
+// Acquisitions
+export async function getAcquisitions(params?: {
+  acquirer_id?: string;
+  target_id?: string;
+  date_from?: string;
+  date_to?: string;
+  sort_by?: string;
+  sort_order?: string;
+  page?: number;
+  page_size?: number;
+}): Promise<PaginatedResponse<Acquisition>> {
+  return fetchApi(`/acquisitions${buildQuery(params || {})}`);
+}
+
+// Stats
 export async function getStats(): Promise<Stats> {
   return fetchApi("/stats");
+}
+
+// Analytics
+export async function getFundingBySector(): Promise<FundingBySector[]> {
+  return fetchApi("/analytics/funding-by-sector");
+}
+
+export async function getFundingByMonth(params?: {
+  sector?: string;
+  months?: number;
+}): Promise<FundingByMonth[]> {
+  return fetchApi(`/analytics/funding-by-month${buildQuery(params || {})}`);
+}
+
+export async function getTopInvestors(params?: {
+  limit?: number;
+}): Promise<TopInvestor[]> {
+  return fetchApi(`/analytics/top-investors${buildQuery(params || {})}`);
+}
+
+export async function getCoInvestors(params?: {
+  limit?: number;
+}): Promise<CoInvestorPair[]> {
+  return fetchApi(`/analytics/co-investors${buildQuery(params || {})}`);
+}
+
+export async function getSectorSummary(): Promise<SectorSummary[]> {
+  return fetchApi("/analytics/sector-summary");
+}
+
+export async function getAcquisitionsSummary(): Promise<AcquisitionSummary[]> {
+  return fetchApi("/analytics/acquisitions-summary");
+}
+
+export async function getRoundTypeDistribution(): Promise<RoundTypeDistribution[]> {
+  return fetchApi("/analytics/round-type-distribution");
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -3,6 +3,9 @@ export interface Company {
   name: string;
   normalized_name: string;
   website: string | null;
+  sector: string | null;
+  revenue_usd: string | null;
+  revenue_as_of_date: string | null;
   created_at: string;
 }
 
@@ -14,6 +17,8 @@ export interface Investor {
   id: string;
   name: string;
   normalized_name: string;
+  investor_type: string | null;
+  website: string | null;
 }
 
 export interface FundingRound {
@@ -25,8 +30,22 @@ export interface FundingRound {
   valuation_usd: string | null;
   announced_date: string | null;
   source_url: string | null;
+  confidence_score: number | null;
   created_at: string;
   investors: Investor[];
+}
+
+export interface Acquisition {
+  id: string;
+  acquirer_id: string;
+  acquirer_name: string | null;
+  target_id: string;
+  target_name: string | null;
+  amount_usd: string | null;
+  announced_date: string | null;
+  source_url: string | null;
+  confidence_score: number | null;
+  created_at: string;
 }
 
 export interface PaginatedResponse<T> {
@@ -41,4 +60,51 @@ export interface Stats {
   total_rounds: number;
   total_investors: number;
   total_funding_usd: number;
+}
+
+// Analytics types
+export interface FundingBySector {
+  sector: string;
+  round_count: number;
+  total_amount: number;
+}
+
+export interface FundingByMonth {
+  month: string;
+  round_count: number;
+  total_amount: number;
+}
+
+export interface TopInvestor {
+  id: string;
+  name: string;
+  deal_count: number;
+  total_invested: number;
+}
+
+export interface CoInvestorPair {
+  investor_a: string;
+  investor_b: string;
+  shared_deals: number;
+}
+
+export interface SectorSummary {
+  sector: string;
+  company_count: number;
+  round_count: number;
+  total_funding: number;
+  avg_round_size: number;
+}
+
+export interface AcquisitionSummary {
+  id: string;
+  name: string;
+  acquisition_count: number;
+  total_spent: number;
+}
+
+export interface RoundTypeDistribution {
+  round_type: string;
+  count: number;
+  total_amount: number;
 }


### PR DESCRIPTION
## Summary
- Updated TypeScript types with sector, revenue, confidence_score, investor_type, Acquisition, and all analytics types
- Expanded API client with getAcquisitions(), all analytics endpoints, new sorting/filtering params
- New SectorBadge component with 15 color-coded sector categories
- Nav updated with Acquisitions and Analytics links
- Company cards show sector badges, detail page shows sector + confidence scores on rounds
- All 37 frontend tests pass, build succeeds

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint clean
- [x] Build succeeds
- [x] All 37 tests pass
- [ ] CI passes

Closes #83

🤖 Generated with [Claude Code](https://claude.com/claude-code)