### PR TITLE
Add analytics dashboard with charts

### DIFF
--- a/frontend/src/app/analytics/page.tsx
+++ b/frontend/src/app/analytics/page.tsx
@@ -1,0 +1,135 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { FundingBySectorChart } from "@/components/charts/FundingBySectorChart";
+import { TopInvestorsChart } from "@/components/charts/TopInvestorsChart";
+import { SectorSummaryTable } from "@/components/charts/SectorSummaryTable";
+import { RoundTypeChart } from "@/components/charts/RoundTypeChart";
+import {
+  getFundingBySector,
+  getTopInvestors,
+  getSectorSummary,
+  getRoundTypeDistribution,
+  getCoInvestors,
+} from "@/lib/api";
+
+export default async function AnalyticsPage() {
+  let fundingBySector;
+  let topInvestors;
+  let sectorSummary;
+  let roundTypes;
+  let coInvestors;
+  let error: string | null = null;
+
+  try {
+    [fundingBySector, topInvestors, sectorSummary, roundTypes, coInvestors] =
+      await Promise.all([
+        getFundingBySector(),
+        getTopInvestors({ limit: 10 }),
+        getSectorSummary(),
+        getRoundTypeDistribution(),
+        getCoInvestors({ limit: 10 }),
+      ]);
+  } catch {
+    error = "Failed to load analytics. Is the backend running?";
+  }
+
+  if (error) {
+    return (
+      <Card className="border-red-200 bg-red-50">
+        <CardContent className="p-4 text-sm text-red-700">{error}</CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Analytics</h1>
+        <p className="text-sm text-gray-500">
+          Market intelligence and funding trends.
+        </p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Funding by Sector */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Funding by Sector</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <FundingBySectorChart data={fundingBySector || []} />
+          </CardContent>
+        </Card>
+
+        {/* Round Type Distribution */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Round Type Distribution
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <RoundTypeChart data={roundTypes || []} />
+          </CardContent>
+        </Card>
+
+        {/* Top Investors */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Top Investors by Deal Count
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <TopInvestorsChart data={topInvestors || []} />
+          </CardContent>
+        </Card>
+
+        {/* Co-Investor Pairs */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Most Frequent Co-Investor Pairs
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {coInvestors && coInvestors.length > 0 ? (
+              <div className="space-y-2">
+                {coInvestors.map((pair, i) => (
+                  <div
+                    key={i}
+                    className="flex items-center justify-between rounded-lg bg-gray-50 px-4 py-2.5"
+                  >
+                    <div className="flex items-center gap-2 text-sm">
+                      <span className="font-medium text-gray-900">
+                        {pair.investor_a}
+                      </span>
+                      <span className="text-gray-400">&</span>
+                      <span className="font-medium text-gray-900">
+                        {pair.investor_b}
+                      </span>
+                    </div>
+                    <span className="rounded-full bg-blue-100 px-2.5 py-0.5 text-xs font-medium text-blue-700">
+                      {pair.shared_deals} deals
+                    </span>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="py-8 text-center text-sm text-gray-400">No data</p>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Sector Summary Table - full width */}
+      <Card className="mt-6">
+        <CardHeader>
+          <CardTitle className="text-base">Sector Summary</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <SectorSummaryTable data={sectorSummary || []} />
+        </CardContent>
+      </Card>
+    </>
+  );
+}

--- a/frontend/src/components/charts/FundingBySectorChart.tsx
+++ b/frontend/src/components/charts/FundingBySectorChart.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  Cell,
+} from "recharts";
+import type { FundingBySector } from "@/lib/types";
+
+const COLORS = [
+  "#8b5cf6", "#10b981", "#f43f5e", "#3b82f6", "#f97316",
+  "#22c55e", "#ef4444", "#eab308", "#f59e0b", "#06b6d4",
+  "#ec4899", "#84cc16", "#64748b", "#6366f1", "#9ca3af",
+];
+
+function formatAmount(value: number): string {
+  if (value >= 1e9) return `$${(value / 1e9).toFixed(1)}B`;
+  if (value >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
+  if (value >= 1e3) return `$${(value / 1e3).toFixed(0)}K`;
+  return `$${value}`;
+}
+
+export function FundingBySectorChart({ data }: { data: FundingBySector[] }) {
+  if (data.length === 0) {
+    return <p className="py-8 text-center text-sm text-gray-400">No data</p>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart data={data} layout="vertical" margin={{ left: 20, right: 20 }}>
+        <XAxis type="number" tickFormatter={formatAmount} />
+        <YAxis
+          type="category"
+          dataKey="sector"
+          width={140}
+          tick={{ fontSize: 12 }}
+        />
+        <Tooltip
+          formatter={(value) => [formatAmount(Number(value)), "Total Funding"]}
+        />
+        <Bar dataKey="total_amount" radius={[0, 4, 4, 0]}>
+          {data.map((_, i) => (
+            <Cell key={i} fill={COLORS[i % COLORS.length]} />
+          ))}
+        </Bar>
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/src/components/charts/RoundTypeChart.tsx
+++ b/frontend/src/components/charts/RoundTypeChart.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import {
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  ResponsiveContainer,
+  Legend,
+} from "recharts";
+import type { RoundTypeDistribution } from "@/lib/types";
+
+const COLORS = [
+  "#8b5cf6", "#22c55e", "#3b82f6", "#6366f1", "#f97316", "#ef4444",
+  "#eab308", "#06b6d4", "#ec4899",
+];
+
+export function RoundTypeChart({ data }: { data: RoundTypeDistribution[] }) {
+  if (data.length === 0) {
+    return <p className="py-8 text-center text-sm text-gray-400">No data</p>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <PieChart>
+        <Pie
+          data={data}
+          dataKey="count"
+          nameKey="round_type"
+          cx="50%"
+          cy="50%"
+          outerRadius={100}
+          label={({ name, value }) => `${name}: ${value}`}
+        >
+          {data.map((_, i) => (
+            <Cell key={i} fill={COLORS[i % COLORS.length]} />
+          ))}
+        </Pie>
+        <Tooltip />
+        <Legend />
+      </PieChart>
+    </ResponsiveContainer>
+  );
+}

--- a/frontend/src/components/charts/SectorSummaryTable.tsx
+++ b/frontend/src/components/charts/SectorSummaryTable.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import type { SectorSummary } from "@/lib/types";
+
+function formatAmount(value: number): string {
+  if (value >= 1e9) return `$${(value / 1e9).toFixed(1)}B`;
+  if (value >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
+  if (value >= 1e3) return `$${(value / 1e3).toFixed(0)}K`;
+  return `$${value.toFixed(0)}`;
+}
+
+export function SectorSummaryTable({ data }: { data: SectorSummary[] }) {
+  if (data.length === 0) {
+    return <p className="py-8 text-center text-sm text-gray-400">No data</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full divide-y divide-gray-200">
+        <thead>
+          <tr className="bg-gray-50/50">
+            <th className="px-4 py-2.5 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+              Sector
+            </th>
+            <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500">
+              Companies
+            </th>
+            <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500">
+              Rounds
+            </th>
+            <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500">
+              Total Funding
+            </th>
+            <th className="px-4 py-2.5 text-right text-xs font-semibold uppercase tracking-wider text-gray-500">
+              Avg Round
+            </th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {data.map((row) => (
+            <tr key={row.sector} className="hover:bg-gray-50/50">
+              <td className="whitespace-nowrap px-4 py-2.5 text-sm font-medium text-gray-900">
+                {row.sector}
+              </td>
+              <td className="whitespace-nowrap px-4 py-2.5 text-right text-sm text-gray-600">
+                {row.company_count}
+              </td>
+              <td className="whitespace-nowrap px-4 py-2.5 text-right text-sm text-gray-600">
+                {row.round_count}
+              </td>
+              <td className="whitespace-nowrap px-4 py-2.5 text-right text-sm font-medium text-gray-900">
+                {formatAmount(row.total_funding)}
+              </td>
+              <td className="whitespace-nowrap px-4 py-2.5 text-right text-sm text-gray-600">
+                {formatAmount(row.avg_round_size)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/components/charts/TopInvestorsChart.tsx
+++ b/frontend/src/components/charts/TopInvestorsChart.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import type { TopInvestor } from "@/lib/types";
+
+function formatAmount(value: number): string {
+  if (value >= 1e9) return `$${(value / 1e9).toFixed(1)}B`;
+  if (value >= 1e6) return `$${(value / 1e6).toFixed(1)}M`;
+  if (value >= 1e3) return `$${(value / 1e3).toFixed(0)}K`;
+  return `$${value}`;
+}
+
+export function TopInvestorsChart({ data }: { data: TopInvestor[] }) {
+  if (data.length === 0) {
+    return <p className="py-8 text-center text-sm text-gray-400">No data</p>;
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={300}>
+      <BarChart
+        data={data.slice(0, 10)}
+        layout="vertical"
+        margin={{ left: 20, right: 20 }}
+      >
+        <XAxis type="number" />
+        <YAxis
+          type="category"
+          dataKey="name"
+          width={140}
+          tick={{ fontSize: 12 }}
+        />
+        <Tooltip
+          formatter={(value, name) => {
+            if (name === "deal_count") return [Number(value), "Deals"];
+            return [formatAmount(Number(value)), "Total Invested"];
+          }}
+        />
+        <Bar dataKey="deal_count" fill="#3b82f6" radius={[0, 4, 4, 0]} />
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/analytics` page with dashboard layout
- Funding by Sector horizontal bar chart (recharts)
- Round Type Distribution pie chart
- Top Investors by Deal Count bar chart
- Co-Investor Pairs list with deal counts
- Sector Summary table (companies, rounds, total funding, avg round size)
- All data fetched server-side via Promise.all for parallel loading

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint clean
- [x] Build succeeds
- [x] All 37 frontend tests pass
- [ ] CI passes

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)