### PR TITLE
Acquisitions page and investor detail profiles

### DIFF
--- a/backend/app/routes/investors.py
+++ b/backend/app/routes/investors.py
@@ -4,8 +4,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.schemas.common import PaginatedResponse
+from app.schemas.funding_round import FundingRoundResponse
 from app.schemas.investor import InvestorResponse
-from app.services.crud import get_investor, list_investors
+from app.services.crud import get_investor, get_investor_rounds, list_investors
 from app.services.db import get_session
 
 router = APIRouter(prefix="/investors", tags=["investors"])
@@ -15,7 +16,7 @@ router = APIRouter(prefix="/investors", tags=["investors"])
 async def list_investors_endpoint(
     search: str | None = Query(None, description="Search by investor name"),
     investor_type: str | None = Query(None, description="Filter by investor type"),
-    sort_by: str = Query("name", description="Sort by: name, created_at"),
+    sort_by: str = Query("name", description="Sort by: name"),
     sort_order: str = Query("asc", description="Sort order: asc or desc"),
     page: int = Query(1, ge=1),
     page_size: int = Query(20, ge=1, le=100),
@@ -38,7 +39,7 @@ async def list_investors_endpoint(
     )
 
 
-@router.get("/{investor_id}", response_model=InvestorResponse)
+@router.get("/{investor_id}")
 async def get_investor_endpoint(
     investor_id: uuid.UUID,
     session: AsyncSession = Depends(get_session),
@@ -46,4 +47,11 @@ async def get_investor_endpoint(
     investor = await get_investor(session, investor_id)
     if not investor:
         raise HTTPException(status_code=404, detail="Investor not found")
-    return InvestorResponse.model_validate(investor)
+
+    rounds = await get_investor_rounds(session, investor_id)
+
+    investor_data = InvestorResponse.model_validate(investor).model_dump()
+    investor_data["funding_rounds"] = [
+        FundingRoundResponse.model_validate(r).model_dump() for r in rounds
+    ]
+    return investor_data

--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -263,6 +263,25 @@ async def get_investor(
     return result.scalar_one_or_none()
 
 
+async def get_investor_rounds(
+    session: AsyncSession,
+    investor_id: uuid.UUID,
+) -> list[FundingRound]:
+    """Get all funding rounds an investor participated in."""
+    stmt = (
+        select(FundingRound)
+        .join(round_investors, round_investors.c.round_id == FundingRound.id)
+        .where(round_investors.c.investor_id == investor_id)
+        .options(
+            selectinload(FundingRound.investors),
+            selectinload(FundingRound.company),
+        )
+        .order_by(FundingRound.announced_date.desc().nullslast())
+    )
+    rows = (await session.execute(stmt)).scalars().unique().all()
+    return list(rows)
+
+
 async def list_investors(
     session: AsyncSession,
     *,

--- a/frontend/src/app/acquisitions/page.tsx
+++ b/frontend/src/app/acquisitions/page.tsx
@@ -1,0 +1,142 @@
+import Link from "next/link";
+import { Handshake } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import Pagination from "@/components/Pagination";
+import { getAcquisitions } from "@/lib/api";
+import { formatUSD, formatDate } from "@/lib/format";
+import type { Acquisition } from "@/lib/types";
+
+interface PageProps {
+  searchParams: Promise<{ page?: string }>;
+}
+
+export default async function AcquisitionsPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const page = parseInt(params.page || "1", 10);
+
+  let data;
+  let error: string | null = null;
+  try {
+    data = await getAcquisitions({ page, page_size: 20 });
+  } catch {
+    error = "Failed to load acquisitions. Is the backend running?";
+  }
+
+  return (
+    <>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Acquisitions</h1>
+        <p className="text-sm text-gray-500">
+          Browse tracked acquisition activity.
+        </p>
+      </div>
+
+      {error ? (
+        <Card className="border-red-200 bg-red-50">
+          <CardContent className="p-4 text-sm text-red-700">
+            {error}
+          </CardContent>
+        </Card>
+      ) : data ? (
+        <>
+          <Card>
+            <div className="overflow-x-auto">
+              <table className="min-w-full divide-y divide-gray-200">
+                <thead>
+                  <tr className="bg-gray-50/50">
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                      Acquirer
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                      Target
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                      Amount
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                      Date
+                    </th>
+                    <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                      Confidence
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-gray-100">
+                  {data.items.map((acq: Acquisition) => (
+                    <tr
+                      key={acq.id}
+                      className="transition-colors hover:bg-gray-50/50"
+                    >
+                      <td className="whitespace-nowrap px-6 py-4">
+                        <Link
+                          href={`/companies/${acq.acquirer_id}`}
+                          className="font-medium text-blue-600 hover:text-blue-800 hover:underline"
+                        >
+                          {acq.acquirer_name || acq.acquirer_id.slice(0, 8)}
+                        </Link>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4">
+                        <Link
+                          href={`/companies/${acq.target_id}`}
+                          className="font-medium text-gray-900 hover:text-blue-600 hover:underline"
+                        >
+                          {acq.target_name || acq.target_id.slice(0, 8)}
+                        </Link>
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
+                        {formatUSD(acq.amount_usd)}
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                        {formatDate(acq.announced_date)}
+                      </td>
+                      <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                        {acq.confidence_score != null ? (
+                          <div className="flex items-center gap-1.5">
+                            <div className="h-1.5 w-12 rounded-full bg-gray-200">
+                              <div
+                                className="h-1.5 rounded-full bg-green-500"
+                                style={{
+                                  width: `${Math.round(acq.confidence_score * 100)}%`,
+                                }}
+                              />
+                            </div>
+                            <span className="text-xs">
+                              {Math.round(acq.confidence_score * 100)}%
+                            </span>
+                          </div>
+                        ) : (
+                          "-"
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </Card>
+
+          {data.items.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-16 text-center">
+              <Handshake className="mb-4 h-12 w-12 text-gray-300" />
+              <p className="text-lg font-medium text-gray-900">
+                No acquisitions yet
+              </p>
+              <p className="mt-1 text-sm text-gray-500">
+                Acquisition data will appear here after ingestion.
+              </p>
+            </div>
+          )}
+
+          <div className="mt-6">
+            <Pagination
+              page={page}
+              pageSize={20}
+              total={data.total}
+              basePath="/acquisitions"
+            />
+          </div>
+        </>
+      ) : null}
+    </>
+  );
+}

--- a/frontend/src/app/investors/[id]/page.tsx
+++ b/frontend/src/app/investors/[id]/page.tsx
@@ -1,0 +1,190 @@
+import { notFound } from "next/navigation";
+import Link from "next/link";
+import {
+  ArrowLeft,
+  Globe,
+  DollarSign,
+  TrendingUp,
+} from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { RoundBadge } from "@/components/ui/badge";
+import { getInvestor } from "@/lib/api";
+import { formatUSD, formatDate } from "@/lib/format";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function InvestorDetailPage({ params }: PageProps) {
+  const { id } = await params;
+
+  let investor;
+  try {
+    investor = await getInvestor(id);
+  } catch {
+    notFound();
+  }
+
+  const totalInvested = investor.funding_rounds.reduce((sum, r) => {
+    return sum + (r.amount_usd ? parseFloat(r.amount_usd) : 0);
+  }, 0);
+
+  const uniqueCompanies = new Set(
+    investor.funding_rounds.map((r) => r.company_name).filter(Boolean)
+  );
+
+  const initials = investor.name
+    .split(" ")
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join("")
+    .toUpperCase();
+
+  return (
+    <>
+      <Link
+        href="/investors"
+        className="mb-6 inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to investors
+      </Link>
+
+      {/* Header */}
+      <Card className="mb-8">
+        <CardContent className="flex flex-col gap-6 p-6 sm:flex-row sm:items-center sm:justify-between">
+          <div className="flex items-center gap-4">
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl bg-gradient-to-br from-emerald-500 to-teal-600 text-lg font-bold text-white">
+              {initials}
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">
+                {investor.name}
+              </h1>
+              {investor.investor_type && (
+                <span className="mt-0.5 inline-block rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-600">
+                  {investor.investor_type}
+                </span>
+              )}
+              {investor.website && (
+                <a
+                  href={investor.website}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="mt-0.5 flex items-center gap-1 text-sm text-blue-600 hover:underline"
+                >
+                  <Globe className="h-3.5 w-3.5" />
+                  {investor.website.replace(/^https?:\/\//, "")}
+                </a>
+              )}
+            </div>
+          </div>
+          <div className="flex gap-6">
+            <div className="text-center">
+              <p className="text-2xl font-bold text-gray-900">
+                {investor.funding_rounds.length}
+              </p>
+              <p className="text-xs text-gray-500">Deals</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-gray-900">
+                {uniqueCompanies.size}
+              </p>
+              <p className="text-xs text-gray-500">Companies</p>
+            </div>
+            <div className="text-center">
+              <p className="text-2xl font-bold text-gray-900">
+                {totalInvested > 0 ? formatUSD(String(totalInvested)) : "-"}
+              </p>
+              <p className="text-xs text-gray-500">Total Invested</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Funding Rounds */}
+      <h2 className="mb-4 text-lg font-semibold text-gray-900">
+        Investment History
+      </h2>
+
+      {investor.funding_rounds.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center py-12 text-center">
+            <TrendingUp className="mb-3 h-10 w-10 text-gray-300" />
+            <p className="text-gray-500">No funding rounds recorded.</p>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-gray-200">
+              <thead>
+                <tr className="bg-gray-50/50">
+                  <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Company
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Round
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Amount
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Date
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-semibold uppercase tracking-wider text-gray-500">
+                    Co-Investors
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {investor.funding_rounds.map((round) => (
+                  <tr
+                    key={round.id}
+                    className="transition-colors hover:bg-gray-50/50"
+                  >
+                    <td className="whitespace-nowrap px-6 py-4">
+                      <Link
+                        href={`/companies/${round.company_id}`}
+                        className="font-medium text-blue-600 hover:text-blue-800 hover:underline"
+                      >
+                        {round.company_name || round.company_id.slice(0, 8)}
+                      </Link>
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4">
+                      <RoundBadge roundType={round.round_type} />
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm font-medium text-gray-900">
+                      {formatUSD(round.amount_usd)}
+                    </td>
+                    <td className="whitespace-nowrap px-6 py-4 text-sm text-gray-500">
+                      {formatDate(round.announced_date)}
+                    </td>
+                    <td className="px-6 py-4 text-sm text-gray-500">
+                      <div className="flex flex-wrap gap-1">
+                        {round.investors
+                          .filter((i) => i.id !== investor.id)
+                          .map((i) => (
+                            <span
+                              key={i.id}
+                              className="rounded bg-gray-100 px-1.5 py-0.5 text-xs text-gray-600"
+                            >
+                              {i.name}
+                            </span>
+                          ))}
+                        {round.investors.filter((i) => i.id !== investor.id)
+                          .length === 0 && (
+                          <span className="text-gray-400">Solo</span>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      )}
+    </>
+  );
+}

--- a/frontend/src/app/investors/page.tsx
+++ b/frontend/src/app/investors/page.tsx
@@ -1,4 +1,5 @@
 import { Suspense } from "react";
+import Link from "next/link";
 import { Users } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import SearchBar from "@/components/SearchBar";
@@ -19,16 +20,25 @@ function InvestorCard({ investor }: { investor: Investor }) {
     .toUpperCase();
 
   return (
-    <Card className="transition-all hover:shadow-md hover:border-blue-200">
-      <CardContent className="flex items-center gap-4 p-5">
-        <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-emerald-500 to-teal-600 text-sm font-bold text-white">
-          {initials}
-        </div>
-        <div className="min-w-0">
-          <h3 className="font-semibold text-gray-900">{investor.name}</h3>
-        </div>
-      </CardContent>
-    </Card>
+    <Link href={`/investors/${investor.id}`} className="group block">
+      <Card className="h-full transition-all group-hover:shadow-md group-hover:border-blue-200">
+        <CardContent className="flex items-center gap-4 p-5">
+          <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-emerald-500 to-teal-600 text-sm font-bold text-white">
+            {initials}
+          </div>
+          <div className="min-w-0">
+            <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
+              {investor.name}
+            </h3>
+            {investor.investor_type && (
+              <p className="mt-0.5 text-xs text-gray-400">
+                {investor.investor_type}
+              </p>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   FundingBySector,
   FundingRound,
   Investor,
+  InvestorDetail,
   PaginatedResponse,
   RoundTypeDistribution,
   SectorSummary,
@@ -80,6 +81,10 @@ export async function getInvestors(params?: {
   page_size?: number;
 }): Promise<PaginatedResponse<Investor>> {
   return fetchApi(`/investors${buildQuery(params || {})}`);
+}
+
+export async function getInvestor(id: string): Promise<InvestorDetail> {
+  return fetchApi(`/investors/${id}`);
 }
 
 // Acquisitions

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -21,6 +21,10 @@ export interface Investor {
   website: string | null;
 }
 
+export interface InvestorDetail extends Investor {
+  funding_rounds: FundingRound[];
+}
+
 export interface FundingRound {
   id: string;
   company_id: string;


### PR DESCRIPTION
## Summary
- New acquisitions list page with table view (acquirer, target, amount, date, confidence)
- New investor detail page with profile stats (deal count, portfolio companies, total invested) and investment history
- Backend: added `get_investor_rounds()` to query funding rounds via junction table
- Investor list cards now link to detail pages and show investor type

Closes #87

## Test plan
- [ ] Verify `/acquisitions` page renders with table layout
- [ ] Verify `/investors/[id]` detail page shows stats and investment history
- [ ] Verify investor cards link to detail pages
- [ ] Backend tests pass for investor rounds query

🤖 Generated with [Claude Code](https://claude.com/claude-code)