### PR TITLE
Reusable FilterBar with sorting and sector filtering

### DIFF
--- a/frontend/src/app/acquisitions/page.tsx
+++ b/frontend/src/app/acquisitions/page.tsx
@@ -1,23 +1,36 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { Handshake } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import FilterBar from "@/components/FilterBar";
 import Pagination from "@/components/Pagination";
 import { getAcquisitions } from "@/lib/api";
 import { formatUSD, formatDate } from "@/lib/format";
 import type { Acquisition } from "@/lib/types";
 
 interface PageProps {
-  searchParams: Promise<{ page?: string }>;
+  searchParams: Promise<{
+    sort_by?: string;
+    sort_order?: string;
+    page?: string;
+  }>;
 }
 
 export default async function AcquisitionsPage({ searchParams }: PageProps) {
   const params = await searchParams;
+  const sortBy = params.sort_by || "";
+  const sortOrder = params.sort_order || "";
   const page = parseInt(params.page || "1", 10);
 
   let data;
   let error: string | null = null;
   try {
-    data = await getAcquisitions({ page, page_size: 20 });
+    data = await getAcquisitions({
+      sort_by: sortBy || undefined,
+      sort_order: sortOrder || undefined,
+      page,
+      page_size: 20,
+    });
   } catch {
     error = "Failed to load acquisitions. Is the backend running?";
   }
@@ -29,6 +42,18 @@ export default async function AcquisitionsPage({ searchParams }: PageProps) {
         <p className="text-sm text-gray-500">
           Browse tracked acquisition activity.
         </p>
+      </div>
+
+      <div className="mb-6">
+        <Suspense fallback={null}>
+          <FilterBar
+            basePath="/acquisitions"
+            sortOptions={[
+              { label: "Date", value: "date" },
+              { label: "Amount", value: "amount" },
+            ]}
+          />
+        </Suspense>
       </div>
 
       {error ? (
@@ -133,6 +158,10 @@ export default async function AcquisitionsPage({ searchParams }: PageProps) {
               pageSize={20}
               total={data.total}
               basePath="/acquisitions"
+              extraParams={{
+                ...(sortBy ? { sort_by: sortBy } : {}),
+                ...(sortOrder ? { sort_order: sortOrder } : {}),
+              }}
             />
           </div>
         </>

--- a/frontend/src/app/funding-rounds/page.tsx
+++ b/frontend/src/app/funding-rounds/page.tsx
@@ -1,11 +1,12 @@
+import { Suspense } from "react";
 import Link from "next/link";
 import { TrendingUp } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { RoundBadge } from "@/components/ui/badge";
+import FilterBar from "@/components/FilterBar";
 import Pagination from "@/components/Pagination";
 import { getFundingRounds } from "@/lib/api";
 import { formatUSD, formatDate } from "@/lib/format";
-import { cn } from "@/lib/utils";
 
 const ROUND_TYPES = [
   "Pre-Seed",
@@ -17,12 +18,19 @@ const ROUND_TYPES = [
 ];
 
 interface PageProps {
-  searchParams: Promise<{ round_type?: string; page?: string }>;
+  searchParams: Promise<{
+    round_type?: string;
+    sort_by?: string;
+    sort_order?: string;
+    page?: string;
+  }>;
 }
 
 export default async function FundingRoundsPage({ searchParams }: PageProps) {
   const params = await searchParams;
   const roundType = params.round_type || "";
+  const sortBy = params.sort_by || "";
+  const sortOrder = params.sort_order || "";
   const page = parseInt(params.page || "1", 10);
 
   let data;
@@ -30,6 +38,8 @@ export default async function FundingRoundsPage({ searchParams }: PageProps) {
   try {
     data = await getFundingRounds({
       round_type: roundType || undefined,
+      sort_by: sortBy || undefined,
+      sort_order: sortOrder || undefined,
       page,
       page_size: 20,
     });
@@ -46,33 +56,22 @@ export default async function FundingRoundsPage({ searchParams }: PageProps) {
         </p>
       </div>
 
-      {/* Filter pills */}
-      <div className="mb-6 flex flex-wrap gap-2">
-        <Link
-          href="/funding-rounds"
-          className={cn(
-            "rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
-            !roundType
-              ? "border-blue-600 bg-blue-50 text-blue-700"
-              : "border-gray-200 text-gray-600 hover:bg-gray-50"
-          )}
-        >
-          All
-        </Link>
-        {ROUND_TYPES.map((rt) => (
-          <Link
-            key={rt}
-            href={`/funding-rounds?round_type=${encodeURIComponent(rt)}`}
-            className={cn(
-              "rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
-              roundType === rt
-                ? "border-blue-600 bg-blue-50 text-blue-700"
-                : "border-gray-200 text-gray-600 hover:bg-gray-50"
-            )}
-          >
-            {rt}
-          </Link>
-        ))}
+      <div className="mb-6">
+        <Suspense fallback={null}>
+          <FilterBar
+            basePath="/funding-rounds"
+            pillFilter={{
+              param: "round_type",
+              options: ROUND_TYPES.map((rt) => ({ label: rt, value: rt })),
+              label: "Type",
+            }}
+            sortOptions={[
+              { label: "Date", value: "date" },
+              { label: "Amount", value: "amount" },
+              { label: "Round Type", value: "round_type" },
+            ]}
+          />
+        </Suspense>
       </div>
 
       {error ? (
@@ -169,7 +168,11 @@ export default async function FundingRoundsPage({ searchParams }: PageProps) {
               pageSize={20}
               total={data.total}
               basePath="/funding-rounds"
-              extraParams={roundType ? { round_type: roundType } : {}}
+              extraParams={{
+                ...(roundType ? { round_type: roundType } : {}),
+                ...(sortBy ? { sort_by: sortBy } : {}),
+                ...(sortOrder ? { sort_order: sortOrder } : {}),
+              }}
             />
           </div>
         </>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,10 +1,11 @@
 import { Suspense } from "react";
 import Link from "next/link";
 import { Building2, TrendingUp, Users, DollarSign, Globe } from "lucide-react";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { SectorBadge } from "@/components/ui/sector-badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import SearchBar from "@/components/SearchBar";
+import FilterBar from "@/components/FilterBar";
 import Pagination from "@/components/Pagination";
 import { getCompanies, getStats } from "@/lib/api";
 import { formatUSD } from "@/lib/format";
@@ -119,13 +120,39 @@ function CompanyCard({ company }: { company: Company }) {
   );
 }
 
+const SECTORS = [
+  "AI/ML",
+  "Fintech",
+  "Healthcare/Biotech",
+  "SaaS/Enterprise",
+  "E-Commerce/Retail",
+  "Climate/Energy",
+  "Cybersecurity",
+  "EdTech",
+  "Real Estate/PropTech",
+  "Transportation/Logistics",
+  "Media/Entertainment",
+  "Food/Agriculture",
+  "Hardware/Robotics",
+  "Crypto/Web3",
+];
+
 interface PageProps {
-  searchParams: Promise<{ search?: string; page?: string }>;
+  searchParams: Promise<{
+    search?: string;
+    sector?: string;
+    sort_by?: string;
+    sort_order?: string;
+    page?: string;
+  }>;
 }
 
 export default async function Home({ searchParams }: PageProps) {
   const params = await searchParams;
   const search = params.search || "";
+  const sector = params.sector || "";
+  const sortBy = params.sort_by || "";
+  const sortOrder = params.sort_order || "";
   const page = parseInt(params.page || "1", 10);
 
   let data;
@@ -133,6 +160,9 @@ export default async function Home({ searchParams }: PageProps) {
   try {
     data = await getCompanies({
       search: search || undefined,
+      sector: sector || undefined,
+      sort_by: sortBy || undefined,
+      sort_order: sortOrder || undefined,
       page,
       page_size: 21,
     });
@@ -155,9 +185,27 @@ export default async function Home({ searchParams }: PageProps) {
         </div>
       </div>
 
-      <div className="mb-6">
+      <div className="mb-4">
         <Suspense fallback={null}>
           <SearchBar />
+        </Suspense>
+      </div>
+
+      <div className="mb-6">
+        <Suspense fallback={null}>
+          <FilterBar
+            basePath="/"
+            pillFilter={{
+              param: "sector",
+              options: SECTORS.map((s) => ({ label: s, value: s })),
+              label: "Sector",
+            }}
+            sortOptions={[
+              { label: "Name", value: "name" },
+              { label: "Date Added", value: "created_at" },
+              { label: "Sector", value: "sector" },
+            ]}
+          />
         </Suspense>
       </div>
 
@@ -195,7 +243,12 @@ export default async function Home({ searchParams }: PageProps) {
               pageSize={21}
               total={data.total}
               basePath="/"
-              extraParams={search ? { search } : {}}
+              extraParams={{
+                ...(search ? { search } : {}),
+                ...(sector ? { sector } : {}),
+                ...(sortBy ? { sort_by: sortBy } : {}),
+                ...(sortOrder ? { sort_order: sortOrder } : {}),
+              }}
             />
           </div>
         </>

--- a/frontend/src/components/FilterBar.tsx
+++ b/frontend/src/components/FilterBar.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+import { ArrowUpDown, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface FilterOption {
+  label: string;
+  value: string;
+}
+
+interface FilterBarProps {
+  basePath: string;
+  /** Pill-style filter for a single param (e.g. round_type, sector) */
+  pillFilter?: {
+    param: string;
+    options: FilterOption[];
+    label?: string;
+  };
+  /** Sort options */
+  sortOptions?: FilterOption[];
+  sortParam?: string;
+  /** Preserve these params across navigations */
+  preserveParams?: string[];
+}
+
+export default function FilterBar({
+  basePath,
+  pillFilter,
+  sortOptions,
+  sortParam = "sort_by",
+  preserveParams = [],
+}: FilterBarProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const buildUrl = useCallback(
+    (updates: Record<string, string | null>) => {
+      const params = new URLSearchParams();
+
+      // Preserve specified params
+      const allPreserve = [
+        ...preserveParams,
+        pillFilter?.param,
+        sortParam,
+        "sort_order",
+        "search",
+      ].filter(Boolean) as string[];
+
+      for (const key of allPreserve) {
+        const val = searchParams.get(key);
+        if (val) params.set(key, val);
+      }
+
+      // Apply updates (null = remove)
+      for (const [key, val] of Object.entries(updates)) {
+        if (val === null) {
+          params.delete(key);
+        } else {
+          params.set(key, val);
+        }
+      }
+
+      // Always reset to page 1 when filtering
+      params.delete("page");
+
+      const qs = params.toString();
+      return qs ? `${basePath}?${qs}` : basePath;
+    },
+    [basePath, searchParams, preserveParams, pillFilter?.param, sortParam],
+  );
+
+  const currentPill = pillFilter ? searchParams.get(pillFilter.param) || "" : "";
+  const currentSort = searchParams.get(sortParam) || "";
+  const currentOrder = searchParams.get("sort_order") || "asc";
+
+  const hasActiveFilters =
+    currentPill || currentSort || searchParams.get("sort_order");
+
+  return (
+    <div className="flex flex-col gap-3">
+      {/* Pill filters */}
+      {pillFilter && (
+        <div className="flex flex-wrap items-center gap-2">
+          {pillFilter.label && (
+            <span className="text-xs font-medium text-gray-500 uppercase tracking-wider mr-1">
+              {pillFilter.label}
+            </span>
+          )}
+          <button
+            onClick={() => router.push(buildUrl({ [pillFilter.param]: null }))}
+            className={cn(
+              "rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+              !currentPill
+                ? "border-blue-600 bg-blue-50 text-blue-700"
+                : "border-gray-200 text-gray-600 hover:bg-gray-50",
+            )}
+          >
+            All
+          </button>
+          {pillFilter.options.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() =>
+                router.push(buildUrl({ [pillFilter.param]: opt.value }))
+              }
+              className={cn(
+                "rounded-full border px-3 py-1.5 text-sm font-medium transition-colors",
+                currentPill === opt.value
+                  ? "border-blue-600 bg-blue-50 text-blue-700"
+                  : "border-gray-200 text-gray-600 hover:bg-gray-50",
+              )}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Sort controls */}
+      {sortOptions && sortOptions.length > 0 && (
+        <div className="flex items-center gap-2">
+          <ArrowUpDown className="h-3.5 w-3.5 text-gray-400" />
+          <span className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Sort
+          </span>
+          {sortOptions.map((opt) => {
+            const isActive = currentSort === opt.value;
+            return (
+              <button
+                key={opt.value}
+                onClick={() => {
+                  if (isActive) {
+                    // Toggle order
+                    const newOrder = currentOrder === "asc" ? "desc" : "asc";
+                    router.push(
+                      buildUrl({
+                        [sortParam]: opt.value,
+                        sort_order: newOrder,
+                      }),
+                    );
+                  } else {
+                    router.push(
+                      buildUrl({
+                        [sortParam]: opt.value,
+                        sort_order: "desc",
+                      }),
+                    );
+                  }
+                }}
+                className={cn(
+                  "inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors",
+                  isActive
+                    ? "border-blue-600 bg-blue-50 text-blue-700"
+                    : "border-gray-200 text-gray-600 hover:bg-gray-50",
+                )}
+              >
+                {opt.label}
+                {isActive && (
+                  <span className="text-[10px]">
+                    {currentOrder === "asc" ? "\u2191" : "\u2193"}
+                  </span>
+                )}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Clear all filters */}
+      {hasActiveFilters && (
+        <button
+          onClick={() => {
+            const params = new URLSearchParams();
+            const search = searchParams.get("search");
+            if (search) params.set("search", search);
+            const qs = params.toString();
+            router.push(qs ? `${basePath}?${qs}` : basePath);
+          }}
+          className="inline-flex w-fit items-center gap-1 text-xs text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          <X className="h-3 w-3" />
+          Clear filters
+        </button>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- New `FilterBar` client component with pill-style category filters and sort toggle controls
- All filter/sort state syncs to URL params (shareable URLs, back/forward works)
- Integrated into companies page (sector filter + name/date/sector sorting)
- Integrated into funding rounds page (round type filter + date/amount/type sorting)
- Integrated into acquisitions page (date/amount sorting)
- Pagination preserves active filters across page navigation
- "Clear filters" button when any filter is active

## Test plan
- [ ] Companies page: sector pills filter correctly, sort toggles work
- [ ] Funding rounds: round type pills work, sort toggles work
- [ ] Acquisitions: sort toggles work
- [ ] URL params preserved across pagination
- [ ] Clear filters resets to default view
- [ ] Frontend build passes with no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)