### PR TITLE
Enhanced stats and seed monitored sources

### DIFF
--- a/backend/alembic/versions/006_seed_monitored_sources.py
+++ b/backend/alembic/versions/006_seed_monitored_sources.py
@@ -1,0 +1,80 @@
+"""Seed monitored_sources with RSS feeds and VC firm press pages.
+
+Revision ID: 006
+Revises: 005
+"""
+
+import uuid
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "006"
+down_revision = "005"
+
+SOURCES = [
+    # RSS Feeds
+    ("TechCrunch", "https://techcrunch.com/feed/", "rss"),
+    ("Crunchbase News", "https://news.crunchbase.com/feed/", "rss"),
+    ("VentureBeat", "https://venturebeat.com/feed/", "rss"),
+    ("The Information", "https://www.theinformation.com/feed", "rss"),
+    ("PitchBook News", "https://pitchbook.com/news/rss", "rss"),
+    ("Fortune Venture", "https://fortune.com/section/venture/feed/", "rss"),
+    ("Axios Pro Rata", "https://www.axios.com/pro/pro-rata/feed", "rss"),
+    ("SaaStr Blog", "https://www.saastr.com/feed/", "rss"),
+    # VC Firm Press/Portfolio Pages
+    ("Andreessen Horowitz", "https://a16z.com/announcements/", "webpage"),
+    ("Sequoia Capital", "https://www.sequoiacap.com/build/", "webpage"),
+    ("Accel", "https://www.accel.com/noteworthy", "webpage"),
+    ("Benchmark", "https://www.benchmark.com/", "webpage"),
+    ("Lightspeed Venture Partners", "https://lsvp.com/news/", "webpage"),
+    ("Greylock Partners", "https://greylock.com/portfolio/", "webpage"),
+    ("Founders Fund", "https://foundersfund.com/the-fund/#portfolio", "webpage"),
+    ("Index Ventures", "https://www.indexventures.com/newsroom/", "webpage"),
+    ("General Catalyst", "https://www.generalcatalyst.com/perspectives", "webpage"),
+    ("Bessemer Venture Partners", "https://www.bvp.com/news", "webpage"),
+    ("Insight Partners", "https://www.insightpartners.com/newsroom/", "webpage"),
+    ("Tiger Global Management", "https://www.tigerglobal.com/", "webpage"),
+    ("Kleiner Perkins", "https://www.kleinerperkins.com/perspectives/", "webpage"),
+    ("NEA", "https://www.nea.com/news", "webpage"),
+    ("Khosla Ventures", "https://www.khoslaventures.com/news", "webpage"),
+    ("GV", "https://www.gv.com/portfolio/", "webpage"),
+    ("Ribbit Capital", "https://ribbitcap.com/", "webpage"),
+    ("Thrive Capital", "https://www.thrivecap.com/", "webpage"),
+    ("Coatue Management", "https://www.coatue.com/ventures", "webpage"),
+    ("Lux Capital", "https://www.luxcapital.com/news", "webpage"),
+]
+
+
+def upgrade():
+    table = sa.table(
+        "monitored_sources",
+        sa.column("id", sa.Uuid),
+        sa.column("name", sa.Text),
+        sa.column("url", sa.Text),
+        sa.column("source_type", sa.Text),
+        sa.column("active", sa.Boolean),
+    )
+    op.bulk_insert(
+        table,
+        [
+            {
+                "id": str(uuid.uuid4()),
+                "name": name,
+                "url": url,
+                "source_type": source_type,
+                "active": True,
+            }
+            for name, url, source_type in SOURCES
+        ],
+    )
+
+
+def downgrade():
+    urls = [url for _, url, _ in SOURCES]
+    op.execute(
+        sa.text("DELETE FROM monitored_sources WHERE url = ANY(:urls)").bindparams(
+            urls=urls,
+        )
+    )

--- a/backend/app/routes/stats.py
+++ b/backend/app/routes/stats.py
@@ -11,6 +11,8 @@ class StatsResponse(BaseModel):
     total_rounds: int
     total_investors: int
     total_funding_usd: float
+    total_acquisitions: int
+    top_sector: str | None
 
 
 router = APIRouter(prefix="/stats", tags=["stats"])

--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -487,11 +487,29 @@ async def get_stats(session: AsyncSession) -> dict:
     total_funding = (
         await session.execute(select(func.coalesce(func.sum(FundingRound.amount_usd), 0)))
     ).scalar_one()
+    total_acquisitions = (
+        await session.execute(select(func.count()).select_from(Acquisition))
+    ).scalar_one()
+
+    # Top sector by company count
+    top_sector_row = (
+        await session.execute(
+            select(Company.sector, func.count().label("cnt"))
+            .where(Company.sector.isnot(None))
+            .group_by(Company.sector)
+            .order_by(func.count().desc())
+            .limit(1)
+        )
+    ).first()
+    top_sector = top_sector_row[0] if top_sector_row else None
+
     return {
         "total_companies": total_companies,
         "total_rounds": total_rounds,
         "total_investors": total_investors,
         "total_funding_usd": float(total_funding),
+        "total_acquisitions": total_acquisitions,
+        "top_sector": top_sector,
     }
 
 

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -231,10 +231,12 @@ class TestStatsAPI:
         assert data["total_rounds"] == 0
         assert data["total_investors"] == 0
         assert data["total_funding_usd"] == 0
+        assert data["total_acquisitions"] == 0
+        assert data["top_sector"] is None
 
     @pytest.mark.asyncio
     async def test_stats_with_data(self, client, session):
-        c = await create_company(session, "Acme Corp")
+        c = await create_company(session, "Acme Corp", sector="AI/ML")
         inv = await create_investor(session, "VC Fund")
         await create_funding_round(
             session,
@@ -251,6 +253,8 @@ class TestStatsAPI:
         assert data["total_rounds"] == 1
         assert data["total_investors"] == 1
         assert data["total_funding_usd"] == 1_000_000
+        assert data["total_acquisitions"] == 0
+        assert data["top_sector"] == "AI/ML"
 
 
 class TestFundingRoundCompanyName:

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,14 @@
 import { Suspense } from "react";
 import Link from "next/link";
-import { Building2, TrendingUp, Users, DollarSign, Globe } from "lucide-react";
+import {
+  Building2,
+  TrendingUp,
+  Users,
+  DollarSign,
+  Globe,
+  Handshake,
+  Layers,
+} from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { SectorBadge } from "@/components/ui/sector-badge";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -41,10 +49,24 @@ async function StatsBar() {
       value: formatUSD(String(stats.total_funding_usd)),
       icon: DollarSign,
     },
+    {
+      label: "Acquisitions",
+      value: stats.total_acquisitions.toLocaleString(),
+      icon: Handshake,
+    },
+    ...(stats.top_sector
+      ? [
+          {
+            label: "Top Sector",
+            value: stats.top_sector,
+            icon: Layers,
+          },
+        ]
+      : []),
   ];
 
   return (
-    <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
       {items.map(({ label, value, icon: Icon }) => (
         <Card key={label}>
           <CardContent className="flex items-center gap-4 p-5">
@@ -64,8 +86,8 @@ async function StatsBar() {
 
 function StatsBarSkeleton() {
   return (
-    <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-      {[...Array(4)].map((_, i) => (
+    <div className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6">
+      {[...Array(6)].map((_, i) => (
         <Card key={i}>
           <CardContent className="flex items-center gap-4 p-5">
             <Skeleton className="h-10 w-10 rounded-lg" />

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -64,6 +64,8 @@ export interface Stats {
   total_rounds: number;
   total_investors: number;
   total_funding_usd: number;
+  total_acquisitions: number;
+  top_sector: string | null;
 }
 
 // Analytics types


### PR DESCRIPTION
## Summary
- Backend `get_stats()` now returns `total_acquisitions` and `top_sector` (most popular sector by company count)
- Seed migration (`006`) pre-populates `monitored_sources` with 8 RSS feeds and 20 VC firm press page URLs
- Frontend stats bar expanded to 6 cards showing all key metrics including acquisitions and top sector
- Updated tests to verify new stats fields

## Test plan
- [ ] Backend tests pass (275 tests)
- [ ] Stats endpoint returns new fields (`total_acquisitions`, `top_sector`)
- [ ] Frontend stats bar shows 6 cards
- [ ] Seed migration inserts 28 monitored sources
- [ ] Frontend build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)