### PR TITLE
Centralize config, deduplicate normalize_name, cap LLM cache

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,28 @@
+"""Centralized application configuration via environment variables."""
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", extra="ignore")
+
+    # Database
+    database_url: str = "postgresql+asyncpg://postgres:postgres@localhost:5432/startuptracker"
+
+    # CORS
+    cors_origins: str = "http://localhost:3000"
+
+    # OpenAI / LLM
+    openai_api_key: str = ""
+    openai_model: str = "gpt-4o-mini"
+    openai_base_url: str = "https://api.openai.com/v1"
+    openai_timeout: int = 30
+
+    # LLM extraction cache
+    llm_cache_max_size: int = 1024
+
+    # RSS fallback
+    feed_urls: str = ""
+
+
+settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,8 +1,7 @@
-import os
-
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.config import settings
 from app.routes.acquisitions import router as acquisitions_router
 from app.routes.analytics import router as analytics_router
 from app.routes.companies import router as companies_router
@@ -15,10 +14,9 @@ from app.routes.stats import router as stats_router
 
 app = FastAPI(title="StartupTracker API", version="0.1.0")
 
-CORS_ORIGINS = os.environ.get("CORS_ORIGINS", "http://localhost:3000").split(",")
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=CORS_ORIGINS,
+    allow_origins=settings.cors_origins.split(","),
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/app/services/cron_ingest.py
+++ b/backend/app/services/cron_ingest.py
@@ -2,8 +2,8 @@
 
 import asyncio
 import logging
-import os
 
+from app.config import settings
 from app.services.crud import get_active_sources, mark_source_checked
 from app.services.db import async_session
 from app.services.ingestion import ingest_rss_feed, ingest_webpage_source
@@ -11,7 +11,7 @@ from app.services.ingestion import ingest_rss_feed, ingest_webpage_source
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-FEED_URLS = [u.strip() for u in os.environ.get("FEED_URLS", "").split(",") if u.strip()]
+FEED_URLS = [u.strip() for u in settings.feed_urls.split(",") if u.strip()]
 
 
 async def main():

--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -1,4 +1,3 @@
-import re
 import uuid
 from datetime import UTC
 
@@ -13,15 +12,7 @@ from app.models.investor import Investor
 from app.models.monitored_source import MonitoredSource
 from app.models.raw_source import RawSource
 from app.models.round_investor import round_investors
-
-
-def normalize_name(name: str) -> str:
-    """Lowercase, strip common suffixes, collapse whitespace."""
-    n = name.lower().strip()
-    n = re.sub(r"\b(inc|llc|ltd|corp|co|plc)\.?\b", "", n)
-    n = re.sub(r"[^\w\s]", "", n)
-    return re.sub(r"\s+", " ", n).strip()
-
+from app.services.normalization import normalize_name
 
 # ---------------------------------------------------------------------------
 # Companies

--- a/backend/app/services/db.py
+++ b/backend/app/services/db.py
@@ -1,13 +1,10 @@
-import os
 from collections.abc import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-DATABASE_URL = os.environ.get(
-    "DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5432/startuptracker"
-)
+from app.config import settings
 
-engine = create_async_engine(DATABASE_URL, echo=False)
+engine = create_async_engine(settings.database_url, echo=False)
 async_session = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 

--- a/backend/app/services/dedup.py
+++ b/backend/app/services/dedup.py
@@ -9,11 +9,8 @@ from app.models.acquisition import Acquisition
 from app.models.company import Company
 from app.models.funding_round import FundingRound
 from app.models.investor import Investor
-from app.services.crud import (
-    create_company,
-    create_investor,
-    normalize_name,
-)
+from app.services.crud import create_company, create_investor
+from app.services.normalization import normalize_name
 
 logger = logging.getLogger(__name__)
 

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -3,21 +3,19 @@
 import hashlib
 import json
 import logging
-import os
+from collections import OrderedDict
 from datetime import date
 from decimal import Decimal
 
 import httpx
 from pydantic import BaseModel, field_validator
 
+from app.config import settings
+
 logger = logging.getLogger(__name__)
 
-OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY", "")
-OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-4o-mini")
-OPENAI_BASE_URL = os.environ.get("OPENAI_BASE_URL", "https://api.openai.com/v1")
-
-# Simple in-memory cache keyed by content hash
-_extraction_cache: dict[str, "ArticleExtraction | None"] = {}
+# LRU-style cache keyed by content hash, capped at settings.llm_cache_max_size
+_extraction_cache: OrderedDict[str, "ArticleExtraction | None"] = OrderedDict()
 
 SYSTEM_PROMPT = """You are a structured data extraction system.
 
@@ -134,6 +132,13 @@ def _content_hash(text: str) -> str:
     return hashlib.sha256(text.encode()).hexdigest()
 
 
+def _cache_put(key: str, value: "ArticleExtraction | None") -> None:
+    """Insert into the LRU cache, evicting oldest entry if full."""
+    _extraction_cache[key] = value
+    if len(_extraction_cache) > settings.llm_cache_max_size:
+        _extraction_cache.popitem(last=False)
+
+
 async def _call_llm(
     article_text: str,
     *,
@@ -142,12 +147,12 @@ async def _call_llm(
     max_retries: int = 2,
 ) -> dict | None:
     """Call LLM API and return parsed JSON dict, or None on failure."""
-    if not OPENAI_API_KEY:
+    if not settings.openai_api_key:
         logger.warning("OPENAI_API_KEY not set, skipping extraction")
         return None
 
     payload = {
-        "model": OPENAI_MODEL,
+        "model": settings.openai_model,
         "messages": [
             {"role": "system", "content": system_prompt},
             {"role": "user", "content": user_prompt},
@@ -158,11 +163,11 @@ async def _call_llm(
 
     for attempt in range(max_retries + 1):
         try:
-            async with httpx.AsyncClient(timeout=30) as client:
+            async with httpx.AsyncClient(timeout=settings.openai_timeout) as client:
                 resp = await client.post(
-                    f"{OPENAI_BASE_URL}/chat/completions",
+                    f"{settings.openai_base_url}/chat/completions",
                     headers={
-                        "Authorization": f"Bearer {OPENAI_API_KEY}",
+                        "Authorization": f"Bearer {settings.openai_api_key}",
                         "Content-Type": "application/json",
                     },
                     json=payload,
@@ -209,16 +214,16 @@ async def extract_article(
     )
 
     if not data:
-        _extraction_cache[h] = None
+        _cache_put(h, None)
         return None
 
     try:
         result = ArticleExtraction.model_validate(data)
-        _extraction_cache[h] = result
+        _cache_put(h, result)
         return result
     except ValueError as e:
         logger.warning("Failed to parse extraction: %s", e)
-        _extraction_cache[h] = None
+        _cache_put(h, None)
         return None
 
 

--- a/backend/app/services/normalization.py
+++ b/backend/app/services/normalization.py
@@ -7,12 +7,16 @@ from decimal import Decimal, InvalidOperation
 from app.services.llm import AcquisitionExtraction, FundingExtraction
 
 
-def normalize_company_name(name: str) -> str:
+def normalize_name(name: str) -> str:
     """Lowercase, strip suffixes (Inc, LLC, etc.), collapse whitespace."""
     n = name.lower().strip()
     n = re.sub(r"\b(inc|llc|ltd|corp|co|plc)\.?\b", "", n)
     n = re.sub(r"[^\w\s]", "", n)
     return re.sub(r"\s+", " ", n).strip()
+
+
+# Backward-compatible alias
+normalize_company_name = normalize_name
 
 
 def normalize_investor_name(name: str) -> str:

--- a/backend/tests/test_crud.py
+++ b/backend/tests/test_crud.py
@@ -14,8 +14,8 @@ from app.services.crud import (
     list_investors,
     list_unprocessed_sources,
     mark_source_processed,
-    normalize_name,
 )
+from app.services.normalization import normalize_name
 
 # ---------------------------------------------------------------------------
 # normalize_name

--- a/backend/tests/test_llm.py
+++ b/backend/tests/test_llm.py
@@ -117,7 +117,7 @@ class TestExtractArticle:
 
     @pytest.mark.asyncio
     async def test_no_api_key(self):
-        with patch("app.services.llm.OPENAI_API_KEY", ""):
+        with patch("app.services.llm.settings.openai_api_key", ""):
             result = await extract_article("some article text")
             assert result is None
 
@@ -140,7 +140,7 @@ class TestExtractArticle:
         mock_client = _mock_llm_response(mock_data)
 
         with (
-            patch("app.services.llm.OPENAI_API_KEY", "test-key"),
+            patch("app.services.llm.settings.openai_api_key", "test-key"),
             patch(
                 "app.services.llm.httpx.AsyncClient",
                 return_value=mock_client,
@@ -171,7 +171,7 @@ class TestExtractArticle:
         mock_client = _mock_llm_response(mock_data)
 
         with (
-            patch("app.services.llm.OPENAI_API_KEY", "test-key"),
+            patch("app.services.llm.settings.openai_api_key", "test-key"),
             patch(
                 "app.services.llm.httpx.AsyncClient",
                 return_value=mock_client,
@@ -190,7 +190,7 @@ class TestExtractArticle:
         mock_client = _mock_llm_response(mock_data)
 
         with (
-            patch("app.services.llm.OPENAI_API_KEY", "test-key"),
+            patch("app.services.llm.settings.openai_api_key", "test-key"),
             patch(
                 "app.services.llm.httpx.AsyncClient",
                 return_value=mock_client,
@@ -209,7 +209,7 @@ class TestExtractArticle:
             event_type="funding",
             funding=FundingExtraction(company="Cached", round_type="Seed"),
         )
-        with patch("app.services.llm.OPENAI_API_KEY", "test-key"):
+        with patch("app.services.llm.settings.openai_api_key", "test-key"):
             h = _content_hash("cached article")
             _extraction_cache[h] = cached
 
@@ -229,7 +229,7 @@ class TestExtractFunding:
 
     @pytest.mark.asyncio
     async def test_no_api_key(self):
-        with patch("app.services.llm.OPENAI_API_KEY", ""):
+        with patch("app.services.llm.settings.openai_api_key", ""):
             result = await extract_funding("some article text")
             assert result is None
 
@@ -252,7 +252,7 @@ class TestExtractFunding:
         mock_client = _mock_llm_response(mock_data)
 
         with (
-            patch("app.services.llm.OPENAI_API_KEY", "test-key"),
+            patch("app.services.llm.settings.openai_api_key", "test-key"),
             patch(
                 "app.services.llm.httpx.AsyncClient",
                 return_value=mock_client,
@@ -278,7 +278,7 @@ class TestExtractFunding:
         mock_client = _mock_llm_response(mock_data)
 
         with (
-            patch("app.services.llm.OPENAI_API_KEY", "test-key"),
+            patch("app.services.llm.settings.openai_api_key", "test-key"),
             patch(
                 "app.services.llm.httpx.AsyncClient",
                 return_value=mock_client,
@@ -294,7 +294,7 @@ class TestExtractFunding:
             event_type="funding",
             funding=FundingExtraction(company="Cached", round_type="Seed"),
         )
-        with patch("app.services.llm.OPENAI_API_KEY", "test-key"):
+        with patch("app.services.llm.settings.openai_api_key", "test-key"):
             h = _content_hash("cached article")
             _extraction_cache[h] = cached
 

--- a/backend/tests/test_llm_edge_cases.py
+++ b/backend/tests/test_llm_edge_cases.py
@@ -56,7 +56,7 @@ class TestExtractFundingEdge:
         mock_client.post = AsyncMock(return_value=mock_resp)
 
         with (
-            patch("app.services.llm.OPENAI_API_KEY", "test-key"),
+            patch("app.services.llm.settings.openai_api_key", "test-key"),
             patch("app.services.llm.httpx.AsyncClient", return_value=mock_client),
         ):
             result = await extract_funding("article text")
@@ -80,7 +80,7 @@ class TestExtractFundingEdge:
         )
 
         with (
-            patch("app.services.llm.OPENAI_API_KEY", "test-key"),
+            patch("app.services.llm.settings.openai_api_key", "test-key"),
             patch("app.services.llm.httpx.AsyncClient", return_value=mock_client),
         ):
             result = await extract_funding("article text http error")
@@ -90,7 +90,7 @@ class TestExtractFundingEdge:
     @pytest.mark.asyncio
     async def test_empty_text(self):
         """Empty article text with no API key should return None."""
-        with patch("app.services.llm.OPENAI_API_KEY", ""):
+        with patch("app.services.llm.settings.openai_api_key", ""):
             result = await extract_funding("")
             assert result is None
 
@@ -113,7 +113,7 @@ class TestExtractFundingEdge:
         mock_client.post = AsyncMock(return_value=mock_resp)
 
         with (
-            patch("app.services.llm.OPENAI_API_KEY", "test-key"),
+            patch("app.services.llm.settings.openai_api_key", "test-key"),
             patch("app.services.llm.httpx.AsyncClient", return_value=mock_client),
         ):
             result = await extract_funding("article text")


### PR DESCRIPTION
## Summary
- New `app/config.py` with Pydantic Settings replacing scattered `os.environ.get()` calls
- Deduplicated `normalize_name`: canonical version in `normalization.py`, removed from `crud.py`
- LLM extraction cache now uses `OrderedDict` capped at 1024 entries (configurable) to prevent memory leak

Closes #93

## Test plan
- [ ] All 275 backend tests pass
- [ ] Config loads defaults correctly when env vars missing
- [ ] LLM cache evicts oldest entries when full
- [ ] No circular imports from normalization change

🤖 Generated with [Claude Code](https://claude.com/claude-code)