### PR TITLE
LLM prompt: populate revenue fields on companies

### DIFF
--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -63,6 +63,34 @@ async def update_company_sector(
         await session.flush()
 
 
+async def update_company_revenue(
+    session: AsyncSession,
+    company_id: uuid.UUID,
+    revenue_usd,
+    revenue_as_of_date=None,
+) -> None:
+    """Update a company's revenue if not already set or if new date is more recent."""
+    stmt = select(Company).where(Company.id == company_id)
+    result = await session.execute(stmt)
+    company = result.scalar_one_or_none()
+    if not company:
+        return
+
+    # Update if company has no revenue, or new data has a more recent date
+    should_update = False
+    if company.revenue_usd is None:
+        should_update = True
+    elif revenue_as_of_date and (
+        company.revenue_as_of_date is None or revenue_as_of_date > company.revenue_as_of_date
+    ):
+        should_update = True
+
+    if should_update:
+        company.revenue_usd = revenue_usd
+        company.revenue_as_of_date = revenue_as_of_date
+        await session.flush()
+
+
 async def list_companies(
     session: AsyncSession,
     *,

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -10,6 +10,7 @@ from app.services.crud import (
     create_raw_source,
     get_raw_source_by_url,
     mark_source_processed,
+    update_company_revenue,
     update_company_sector,
 )
 from app.services.dedup import (
@@ -41,6 +42,12 @@ async def _handle_funding(session, extraction, url, raw):
     # Update sector if LLM provided one and company doesn't have one
     if validated.sector:
         await update_company_sector(session, company.id, validated.sector)
+
+    # Update revenue if LLM extracted it
+    if validated.revenue_usd:
+        await update_company_revenue(
+            session, company.id, validated.revenue_usd, validated.revenue_as_of_date
+        )
 
     if await is_duplicate_round(
         session,

--- a/backend/app/services/llm.py
+++ b/backend/app/services/llm.py
@@ -35,6 +35,7 @@ Rules:
 Healthcare/Biotech, SaaS/Enterprise, E-Commerce/Retail, Climate/Energy, \
 Cybersecurity, EdTech, Real Estate/PropTech, Transportation/Logistics, \
 Media/Entertainment, Food/Agriculture, Hardware/Robotics, Crypto/Web3, Other
+- If annual revenue or ARR is explicitly mentioned, extract as revenue_usd and revenue_as_of_date
 - Do not include explanations"""
 
 USER_PROMPT_TEMPLATE = """Analyze the following article and extract structured data:
@@ -56,7 +57,8 @@ If "funding", return:
     "announcement_date": "YYYY-MM-DD" | null,
     "sector": "sector name" | null,
     "confidence_score": number (0.0-1.0),
-    "revenue_usd": number | null
+    "revenue_usd": number | null,
+    "revenue_as_of_date": "YYYY-MM-DD" | null
   }}
 }}
 
@@ -100,6 +102,7 @@ class FundingExtraction(BaseModel):
     sector: str | None = None
     confidence_score: float | None = None
     revenue_usd: Decimal | None = None
+    revenue_as_of_date: date | None = None
 
     @field_validator("round_type")
     @classmethod

--- a/backend/app/services/normalization.py
+++ b/backend/app/services/normalization.py
@@ -78,6 +78,7 @@ def validate_extraction(extraction: FundingExtraction) -> FundingExtraction | No
         sector=extraction.sector,
         confidence_score=extraction.confidence_score,
         revenue_usd=parse_amount(extraction.revenue_usd),
+        revenue_as_of_date=parse_date(extraction.revenue_as_of_date),
     )
 
 


### PR DESCRIPTION
## Summary
- Add revenue_as_of_date to LLM prompt template and FundingExtraction model
- validate_extraction() passes through revenue_as_of_date
- New update_company_revenue() updates company if newer date or no existing data
- Ingestion pipeline writes revenue to company during funding processing

Closes #96

## Test plan
- [ ] All 275 backend tests pass
- [ ] LLM prompt now requests revenue_as_of_date alongside revenue_usd
- [ ] Revenue only updates if new data is more recent than existing

Generated with Claude Code