### PR TITLE
Frontend: source management UI

### DIFF
--- a/frontend/src/app/sources/page.tsx
+++ b/frontend/src/app/sources/page.tsx
@@ -1,0 +1,113 @@
+import { Rss } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import SourceForm from "@/components/SourceForm";
+import SourceToggle from "@/components/SourceToggle";
+import { getSources } from "@/lib/api";
+import { formatDate } from "@/lib/format";
+import type { MonitoredSource } from "@/lib/types";
+
+export default async function SourcesPage() {
+  let sources: MonitoredSource[] = [];
+  let error: string | null = null;
+
+  try {
+    const data = await getSources({ page_size: 100 });
+    sources = data.items;
+  } catch {
+    error = "Failed to load sources. Is the backend running?";
+  }
+
+  return (
+    <>
+      <div className="mb-6">
+        <h1 className="text-2xl font-bold text-gray-900">Sources</h1>
+        <p className="text-sm text-gray-500">
+          Manage monitored RSS feeds and webpages.
+        </p>
+      </div>
+
+      <div className="mb-6">
+        <SourceForm />
+      </div>
+
+      {error ? (
+        <Card className="border-red-200 bg-red-50">
+          <CardContent className="p-4 text-sm text-red-700">{error}</CardContent>
+        </Card>
+      ) : sources.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center">
+          <Rss className="mb-4 h-12 w-12 text-gray-300" />
+          <p className="text-lg font-medium text-gray-900">No sources yet</p>
+          <p className="mt-1 text-sm text-gray-500">
+            Add an RSS feed or webpage above to start monitoring.
+          </p>
+        </div>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Name
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  URL
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Type
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Last Checked
+                </th>
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+                  Active
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-200">
+              {sources.map((source) => (
+                <tr key={source.id} className="hover:bg-gray-50">
+                  <td className="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+                    {source.name}
+                  </td>
+                  <td className="max-w-xs truncate px-4 py-3 text-sm text-gray-500">
+                    <a
+                      href={source.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-blue-600 hover:underline"
+                    >
+                      {source.url.replace(/^https?:\/\//, "")}
+                    </a>
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                        source.source_type === "rss"
+                          ? "bg-orange-100 text-orange-700"
+                          : "bg-purple-100 text-purple-700"
+                      }`}
+                    >
+                      {source.source_type === "rss" ? "RSS" : "Webpage"}
+                    </span>
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+                    {source.last_checked_at
+                      ? formatDate(source.last_checked_at)
+                      : "Never"}
+                  </td>
+                  <td className="whitespace-nowrap px-4 py-3">
+                    <SourceToggle
+                      sourceId={source.id}
+                      initialActive={source.active}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/src/components/Nav.tsx
+++ b/frontend/src/components/Nav.tsx
@@ -12,6 +12,7 @@ import {
   BarChart3,
   Handshake,
   PieChart,
+  Rss,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 
@@ -21,6 +22,7 @@ const NAV_ITEMS = [
   { href: "/acquisitions", label: "Acquisitions", icon: Handshake },
   { href: "/investors", label: "Investors", icon: Users },
   { href: "/analytics", label: "Analytics", icon: PieChart },
+  { href: "/sources", label: "Sources", icon: Rss },
 ];
 
 export default function Nav() {

--- a/frontend/src/components/SourceForm.tsx
+++ b/frontend/src/components/SourceForm.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Plus, ChevronDown, ChevronUp } from "lucide-react";
+import { createSource } from "@/lib/api";
+
+export default function SourceForm() {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+  const [sourceType, setSourceType] = useState("rss");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError("");
+    setLoading(true);
+    try {
+      await createSource({ name, url, source_type: sourceType });
+      setName("");
+      setUrl("");
+      setSourceType("rss");
+      setOpen(false);
+      router.refresh();
+    } catch {
+      setError("Failed to add source. Check the URL is unique.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      >
+        <span className="flex items-center gap-2">
+          <Plus className="h-4 w-4" />
+          Add Source
+        </span>
+        {open ? (
+          <ChevronUp className="h-4 w-4 text-gray-400" />
+        ) : (
+          <ChevronDown className="h-4 w-4 text-gray-400" />
+        )}
+      </button>
+
+      {open && (
+        <form onSubmit={handleSubmit} className="border-t border-gray-200 p-4">
+          <div className="grid gap-4 sm:grid-cols-3">
+            <div>
+              <label className="mb-1 block text-xs font-medium text-gray-500">
+                Name
+              </label>
+              <input
+                type="text"
+                required
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="TechCrunch"
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-gray-500">
+                URL
+              </label>
+              <input
+                type="url"
+                required
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://techcrunch.com/feed/"
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              />
+            </div>
+            <div>
+              <label className="mb-1 block text-xs font-medium text-gray-500">
+                Type
+              </label>
+              <select
+                value={sourceType}
+                onChange={(e) => setSourceType(e.target.value)}
+                className="w-full rounded-lg border border-gray-200 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+              >
+                <option value="rss">RSS Feed</option>
+                <option value="webpage">Webpage</option>
+              </select>
+            </div>
+          </div>
+
+          {error && (
+            <p className="mt-3 text-sm text-red-600">{error}</p>
+          )}
+
+          <div className="mt-4 flex justify-end">
+            <button
+              type="submit"
+              disabled={loading}
+              className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+            >
+              {loading ? "Adding…" : "Add Source"}
+            </button>
+          </div>
+        </form>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/SourceToggle.tsx
+++ b/frontend/src/components/SourceToggle.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { updateSource } from "@/lib/api";
+
+export default function SourceToggle({
+  sourceId,
+  initialActive,
+}: {
+  sourceId: string;
+  initialActive: boolean;
+}) {
+  const router = useRouter();
+  const [active, setActive] = useState(initialActive);
+  const [loading, setLoading] = useState(false);
+
+  async function toggle() {
+    setLoading(true);
+    try {
+      await updateSource(sourceId, { active: !active });
+      setActive(!active);
+      router.refresh();
+    } catch {
+      // revert on error
+      setActive(active);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <button
+      onClick={toggle}
+      disabled={loading}
+      className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 ${
+        active ? "bg-blue-600" : "bg-gray-200"
+      }`}
+    >
+      <span
+        className={`pointer-events-none inline-block h-5 w-5 rounded-full bg-white shadow ring-0 transition-transform duration-200 ${
+          active ? "translate-x-5" : "translate-x-0"
+        }`}
+      />
+    </button>
+  );
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,6 +9,7 @@ import type {
   FundingRound,
   Investor,
   InvestorDetail,
+  MonitoredSource,
   PaginatedResponse,
   RoundTypeDistribution,
   SectorSummary,
@@ -140,4 +141,41 @@ export async function getAcquisitionsSummary(): Promise<AcquisitionSummary[]> {
 
 export async function getRoundTypeDistribution(): Promise<RoundTypeDistribution[]> {
   return fetchApi("/analytics/round-type-distribution");
+}
+
+// Sources
+export async function getSources(params?: {
+  source_type?: string;
+  active?: boolean;
+  page?: number;
+  page_size?: number;
+}): Promise<PaginatedResponse<MonitoredSource>> {
+  const queryParams: Record<string, string | number | undefined> = {
+    source_type: params?.source_type,
+    page: params?.page,
+    page_size: params?.page_size,
+  };
+  if (params?.active !== undefined) queryParams.active = params.active ? "true" : "false";
+  return fetchApi(`/sources${buildQuery(queryParams)}`);
+}
+
+export async function createSource(data: {
+  name: string;
+  url: string;
+  source_type: string;
+}): Promise<MonitoredSource> {
+  return fetchApi("/sources", {
+    method: "POST",
+    body: JSON.stringify(data),
+  });
+}
+
+export async function updateSource(
+  id: string,
+  data: { active?: boolean; name?: string; url?: string; source_type?: string },
+): Promise<MonitoredSource> {
+  return fetchApi(`/sources/${id}`, {
+    method: "PATCH",
+    body: JSON.stringify(data),
+  });
 }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -114,3 +114,14 @@ export interface RoundTypeDistribution {
   count: number;
   total_amount: number;
 }
+
+export interface MonitoredSource {
+  id: string;
+  name: string;
+  url: string;
+  source_type: string;
+  investor_id: string | null;
+  active: boolean;
+  last_checked_at: string | null;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary
- New `/sources` page with table showing all monitored RSS feeds and webpages
- Collapsible form to add new sources (name, URL, type)
- Toggle switch to activate/deactivate individual sources
- Added `MonitoredSource` type and `getSources`/`createSource`/`updateSource` API functions
- Added "Sources" nav item with RSS icon

Closes #104

## Test plan
- [ ] Navigate to Sources page, verify table renders
- [ ] Add a new source via form, verify it appears in table
- [ ] Toggle a source active/inactive, verify state persists
- [ ] Verify empty state shows when no sources exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)