### PR TITLE
Frontend: clickable chart drill-down navigation

### DIFF
--- a/frontend/src/components/charts/FundingBySectorChart.tsx
+++ b/frontend/src/components/charts/FundingBySectorChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import {
   BarChart,
   Bar,
@@ -25,6 +26,8 @@ function formatAmount(value: number): string {
 }
 
 export function FundingBySectorChart({ data }: { data: FundingBySector[] }) {
+  const router = useRouter();
+
   if (data.length === 0) {
     return <p className="py-8 text-center text-sm text-gray-400">No data</p>;
   }
@@ -42,7 +45,15 @@ export function FundingBySectorChart({ data }: { data: FundingBySector[] }) {
         <Tooltip
           formatter={(value) => [formatAmount(Number(value)), "Total Funding"]}
         />
-        <Bar dataKey="total_amount" radius={[0, 4, 4, 0]}>
+        <Bar
+          dataKey="total_amount"
+          radius={[0, 4, 4, 0]}
+          className="cursor-pointer"
+          onClick={(_entry, index) => {
+            const sector = data[index]?.sector;
+            if (sector) router.push(`/?sector=${encodeURIComponent(sector)}`);
+          }}
+        >
           {data.map((_, i) => (
             <Cell key={i} fill={COLORS[i % COLORS.length]} />
           ))}

--- a/frontend/src/components/charts/RoundTypeChart.tsx
+++ b/frontend/src/components/charts/RoundTypeChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import {
   PieChart,
   Pie,
@@ -16,6 +17,8 @@ const COLORS = [
 ];
 
 export function RoundTypeChart({ data }: { data: RoundTypeDistribution[] }) {
+  const router = useRouter();
+
   if (data.length === 0) {
     return <p className="py-8 text-center text-sm text-gray-400">No data</p>;
   }
@@ -31,6 +34,13 @@ export function RoundTypeChart({ data }: { data: RoundTypeDistribution[] }) {
           cy="50%"
           outerRadius={100}
           label={({ name, value }) => `${name}: ${value}`}
+          className="cursor-pointer"
+          onClick={(_entry, index) => {
+            const roundType = data[index]?.round_type;
+            if (roundType) {
+              router.push(`/funding-rounds?round_type=${encodeURIComponent(roundType)}`);
+            }
+          }}
         >
           {data.map((_, i) => (
             <Cell key={i} fill={COLORS[i % COLORS.length]} />

--- a/frontend/src/components/charts/SectorSummaryTable.tsx
+++ b/frontend/src/components/charts/SectorSummaryTable.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import type { SectorSummary } from "@/lib/types";
 
 function formatAmount(value: number): string {
@@ -39,8 +40,13 @@ export function SectorSummaryTable({ data }: { data: SectorSummary[] }) {
         <tbody className="divide-y divide-gray-100">
           {data.map((row) => (
             <tr key={row.sector} className="hover:bg-gray-50/50">
-              <td className="whitespace-nowrap px-4 py-2.5 text-sm font-medium text-gray-900">
-                {row.sector}
+              <td className="whitespace-nowrap px-4 py-2.5 text-sm font-medium">
+                <Link
+                  href={`/?sector=${encodeURIComponent(row.sector)}`}
+                  className="text-blue-600 hover:underline"
+                >
+                  {row.sector}
+                </Link>
               </td>
               <td className="whitespace-nowrap px-4 py-2.5 text-right text-sm text-gray-600">
                 {row.company_count}

--- a/frontend/src/components/charts/TopInvestorsChart.tsx
+++ b/frontend/src/components/charts/TopInvestorsChart.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useRouter } from "next/navigation";
 import {
   BarChart,
   Bar,
@@ -18,6 +19,8 @@ function formatAmount(value: number): string {
 }
 
 export function TopInvestorsChart({ data }: { data: TopInvestor[] }) {
+  const router = useRouter();
+
   if (data.length === 0) {
     return <p className="py-8 text-center text-sm text-gray-400">No data</p>;
   }
@@ -42,7 +45,16 @@ export function TopInvestorsChart({ data }: { data: TopInvestor[] }) {
             return [formatAmount(Number(value)), "Total Invested"];
           }}
         />
-        <Bar dataKey="deal_count" fill="#3b82f6" radius={[0, 4, 4, 0]} />
+        <Bar
+          dataKey="deal_count"
+          fill="#3b82f6"
+          radius={[0, 4, 4, 0]}
+          className="cursor-pointer"
+          onClick={(_entry, index) => {
+            const investor = data[index];
+            if (investor?.id) router.push(`/investors/${investor.id}`);
+          }}
+        />
       </BarChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
## Summary
- Clicking a sector bar on Funding by Sector chart navigates to companies filtered by that sector
- Clicking an investor bar navigates to that investor detail page
- Clicking a round type pie slice navigates to funding rounds filtered by that type
- Sector names in the summary table are now clickable links to filtered company views

Closes #105

## Test plan
- [ ] Click sector bar navigates to /?sector=X
- [ ] Click investor bar navigates to /investors/{id}
- [ ] Click pie slice navigates to /funding-rounds?round_type=X
- [ ] Click sector name in table navigates to filtered companies

Generated with Claude Code