### PR TITLE
Company status tracking with auto-acquired badges

### DIFF
--- a/backend/alembic/versions/007_add_company_status.py
+++ b/backend/alembic/versions/007_add_company_status.py
@@ -1,0 +1,25 @@
+"""Add status column to companies table.
+
+Revision ID: 007
+Revises: 006
+"""
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = "007"
+down_revision = "006"
+
+
+def upgrade() -> None:
+    op.add_column(
+        "companies",
+        sa.Column("status", sa.Text(), server_default="active", nullable=False),
+    )
+    op.create_index("ix_companies_status", "companies", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_companies_status", "companies")
+    op.drop_column("companies", "status")

--- a/backend/app/models/company.py
+++ b/backend/app/models/company.py
@@ -18,5 +18,6 @@ class Company(Base, TimestampMixin):
     sector: Mapped[str | None] = mapped_column(Text, nullable=True, index=True)
     revenue_usd: Mapped[Decimal | None] = mapped_column(Numeric, nullable=True)
     revenue_as_of_date: Mapped[date | None] = mapped_column(Date, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, server_default="active", index=True)
 
     funding_rounds = relationship("FundingRound", back_populates="company", lazy="selectin")

--- a/backend/app/schemas/company.py
+++ b/backend/app/schemas/company.py
@@ -11,6 +11,7 @@ class CompanyBase(BaseModel):
     sector: str | None = None
     revenue_usd: Decimal | None = None
     revenue_as_of_date: date | None = None
+    status: str = "active"
 
 
 class CompanyCreate(CompanyBase):

--- a/backend/app/services/crud.py
+++ b/backend/app/services/crud.py
@@ -91,6 +91,20 @@ async def update_company_revenue(
         await session.flush()
 
 
+async def update_company_status(
+    session: AsyncSession,
+    company_id: uuid.UUID,
+    status: str,
+) -> None:
+    """Update a company's status (e.g., 'acquired', 'ipo', 'defunct')."""
+    stmt = select(Company).where(Company.id == company_id)
+    result = await session.execute(stmt)
+    company = result.scalar_one_or_none()
+    if company:
+        company.status = status
+        await session.flush()
+
+
 async def list_companies(
     session: AsyncSession,
     *,

--- a/backend/app/services/ingestion.py
+++ b/backend/app/services/ingestion.py
@@ -12,6 +12,7 @@ from app.services.crud import (
     mark_source_processed,
     update_company_revenue,
     update_company_sector,
+    update_company_status,
 )
 from app.services.dedup import (
     get_or_create_company,
@@ -124,6 +125,9 @@ async def _handle_acquisition(session, extraction, url, raw):
         source_url=url,
         confidence_score=validated.confidence_score,
     )
+
+    # Mark the target company as acquired
+    await update_company_status(session, target.id, "acquired")
 
     await mark_source_processed(session, raw.id)
 

--- a/frontend/src/app/companies/[id]/page.tsx
+++ b/frontend/src/app/companies/[id]/page.tsx
@@ -78,11 +78,24 @@ export default async function CompanyDetailPage({ params }: PageProps) {
               <h1 className="text-2xl font-bold text-gray-900">
                 {company.name}
               </h1>
-              {company.sector && (
-                <div className="mt-1">
-                  <SectorBadge sector={company.sector} />
-                </div>
-              )}
+              <div className="mt-1 flex flex-wrap items-center gap-1.5">
+                {company.sector && <SectorBadge sector={company.sector} />}
+                {company.status && company.status !== "active" && (
+                  <span
+                    className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                      company.status === "acquired"
+                        ? "bg-amber-100 text-amber-700"
+                        : company.status === "ipo"
+                          ? "bg-green-100 text-green-700"
+                          : company.status === "defunct"
+                            ? "bg-red-100 text-red-700"
+                            : "bg-gray-100 text-gray-700"
+                    }`}
+                  >
+                    {company.status.charAt(0).toUpperCase() + company.status.slice(1)}
+                  </span>
+                )}
+              </div>
               {company.website && (
                 <a
                   href={company.website}

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -124,11 +124,24 @@ function CompanyCard({ company }: { company: Company }) {
             <h3 className="font-semibold text-gray-900 group-hover:text-blue-600 transition-colors">
               {company.name}
             </h3>
-            {company.sector && (
-              <div className="mt-1">
-                <SectorBadge sector={company.sector} />
-              </div>
-            )}
+            <div className="mt-1 flex flex-wrap items-center gap-1.5">
+              {company.sector && <SectorBadge sector={company.sector} />}
+              {company.status && company.status !== "active" && (
+                <span
+                  className={`inline-flex rounded-full px-2 py-0.5 text-xs font-medium ${
+                    company.status === "acquired"
+                      ? "bg-amber-100 text-amber-700"
+                      : company.status === "ipo"
+                        ? "bg-green-100 text-green-700"
+                        : company.status === "defunct"
+                          ? "bg-red-100 text-red-700"
+                          : "bg-gray-100 text-gray-700"
+                  }`}
+                >
+                  {company.status.charAt(0).toUpperCase() + company.status.slice(1)}
+                </span>
+              )}
+            </div>
             {company.website && (
               <p className="mt-0.5 flex items-center gap-1 text-sm text-gray-400 truncate">
                 <Globe className="h-3 w-3" />

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -6,6 +6,7 @@ export interface Company {
   sector: string | null;
   revenue_usd: string | null;
   revenue_as_of_date: string | null;
+  status: string;
   created_at: string;
 }
 


### PR DESCRIPTION
## Summary
- Alembic migration 007: adds indexed `status` column to companies (default: active)
- New `update_company_status()` CRUD function
- Ingestion pipeline auto-sets target company to `acquired` after creating acquisition
- Status badge shown on company cards (home page) and detail page header
- Color-coded: amber (acquired), green (ipo), red (defunct)

Closes #108

## Test plan
- [ ] Run migration 007 against database
- [ ] Ingest an acquisition article, verify target company gets acquired status
- [ ] Verify acquired badge shows on company card and detail page
- [ ] Verify active companies show no badge (clean default)
- [ ] All 275 backend tests pass

Generated with Claude Code